### PR TITLE
feat: align long-action callback contract with webapp

### DIFF
--- a/src/actions/actions/guided_visualization_action.py
+++ b/src/actions/actions/guided_visualization_action.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 _ECHO_INTERNAL_ERRORS = env_util.env_flag("ACTIONS_ECHO_INTERNAL_ERRORS", default=False)
 _SHOW_EXECUTION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_EXECUTION_SUMMARY", default=True)
 _SHOW_NORMALIZATION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_NORMALIZATION_SUMMARY", default=True)
+_EMIT_QUERY_DEBUG = env_util.env_flag("ACTIONS_EMIT_QUERY_DEBUG", default=False)
 
 _executor_concurrency_raw = env_util.get_env("ACTIONS_EXECUTOR_MAX_CONCURRENCY", default="4") or "4"
 try:
@@ -138,7 +139,8 @@ class ActionGuidedGenerateVisualization(Action):  # pyright: ignore
                             "query": query_pretty,
                         }
                     )
-                    dispatcher.utter_message(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
+                    if _EMIT_QUERY_DEBUG:
+                        dispatcher.utter_message(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
 
                 plan_obj = build_guided_plan(slots=slots, user_sub=user_sub, trace_id=trace_id)
                 dispatcher.utter_message(

--- a/src/actions/actions/visualization_action.py
+++ b/src/actions/actions/visualization_action.py
@@ -37,6 +37,7 @@ _ECHO_INTERNAL_ERRORS = env_util.env_flag("ACTIONS_ECHO_INTERNAL_ERRORS", defaul
 _SHOW_EXECUTION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_EXECUTION_SUMMARY", default=True)
 _DEFER_CALLBACK_HANDOFF = env_util.env_flag("LONG_ACTION_DEFER_CALLBACK_HANDOFF", default=False)
 _SHOW_NORMALIZATION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_NORMALIZATION_SUMMARY", default=True)
+_EMIT_QUERY_DEBUG = env_util.env_flag("ACTIONS_EMIT_QUERY_DEBUG", default=False)
 _VISUALIZATION_CONTINUATION_INTENTS = {
     "generate_visualization",
     "update_visualization",
@@ -935,7 +936,8 @@ class ActionOneShotGenerateVisualization(LongAction):
                             "query": query_pretty,
                         }
                     )
-                    ctx.say(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
+                    if _EMIT_QUERY_DEBUG:
+                        ctx.say(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
 
                 # In deferred-handoff mode, initial routing/clarification can use
                 # normal dispatcher delivery and heavy generation streams via

--- a/src/actions/long_action/long_action.py
+++ b/src/actions/long_action/long_action.py
@@ -330,6 +330,54 @@ class LongAction(Action, ABC):
     def _release_message() -> Dict[str, str]:
         return {"type": "release"}
 
+    @staticmethod
+    def _is_control_message(message: Dict[str, Any]) -> bool:
+        """Return True if this is a lock/release control signal, not a user-visible message."""
+        return message.get("type") in {"lock", "release"}
+
+    @staticmethod
+    def _message_to_tracker_event(message: Dict[str, Any], trace_id: Optional[str] = None) -> Dict[str, Any]:
+        """Convert a ctx.say kwargs dict to a tracker bot event shape."""
+        event: Dict[str, Any] = {
+            "event": "bot",
+            "metadata": {
+                "source": "long-task-callback",
+                **(({"trace_id": trace_id}) if isinstance(trace_id, str) and trace_id.strip() else {}),
+            },
+        }
+        if isinstance(message.get("text"), str):
+            event["text"] = message["text"]
+        custom = message.get("custom")
+        if custom and isinstance(custom, dict):
+            event["data"] = {"custom": custom}
+        buttons = message.get("buttons")
+        if buttons and isinstance(buttons, list):
+            event["data"] = {**(event.get("data") or {}), "buttons": buttons}
+        return event
+
+    def _build_callback_payload(
+        self,
+        ctx: "LongActionContext",
+        message: Dict[str, Any],
+        trace_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build the callback payload in the events/controls envelope format."""
+        payload: Dict[str, Any] = {"senderId": ctx.sender_id}
+        if self._is_control_message(message):
+            job_id = getattr(ctx, "_job_id", None) or ""
+            payload["controls"] = [{
+                "type": message["type"],
+                "jobId": job_id,
+                "scope": "long_action",
+                "source": "long-task-callback",
+                **(({"traceId": trace_id}) if isinstance(trace_id, str) and trace_id.strip() else {}),
+            }]
+            payload["events"] = []
+        else:
+            payload["events"] = [self._message_to_tracker_event(message, trace_id)]
+            payload["controls"] = []
+        return payload
+
     async def prework(self, ctx: LongActionContext) -> PreworkResult:
         """Optional in-band phase before work() starts.
 
@@ -390,10 +438,8 @@ class LongAction(Action, ABC):
             job_id = uuid.uuid4().hex
 
             if _DEFER_CALLBACK_HANDOFF:
-                # Optional hybrid mode: start in normal dispatcher path and let the
-                # action explicitly switch to callback transport via
-                # ctx.enable_callback_mode().
                 ctx = LongActionContext(sender_id=sender_id, tracker_snapshot=tracker_snapshot, dispatcher=dispatcher)
+                ctx._job_id = job_id
                 ctx.attach_progress_callback(
                     lambda message, ctx=ctx, job_id=job_id, callback_url=callback_url, callback_token=callback_token: self._post_progress(
                         ctx,
@@ -424,6 +470,7 @@ class LongAction(Action, ABC):
                 return [*immediate_events, *ctx.pending_events]
 
             ctx = LongActionContext(sender_id=sender_id, tracker_snapshot=tracker_snapshot)
+            ctx._job_id = job_id
 
             # In callback mode, stream every ctx.say() as a progress callback to
             # the frontend while the job is running.
@@ -456,20 +503,17 @@ class LongAction(Action, ABC):
     ) -> None:
         """Send a callback for a single ctx.say() message.
 
-        The payload shape is kept intentionally simple and dispatcher-like so
-        the frontend can treat it similarly to Rasa messages:
+        Payload envelope:
+        - Real messages go in ``events`` as tracker bot-event objects.
+        - Lock/release control signals go in ``controls`` as control objects.
 
-        {
-            "senderId": "...",
-            "messages": [ { ...ctx.say kwargs... } ]
-        }
+        {"senderId": ..., "events": [{"event": "bot", ...}], "controls": []}
+        or
+        {"senderId": ..., "events": [], "controls": [{"type": "lock|release", ...}]}
         """
 
-        payload: Dict[str, Any] = {
-            "senderId": ctx.sender_id,
-            "messages": [message],
-        }
         trace_id = _resolve_progress_trace_id(ctx, message)
+        payload: Dict[str, Any] = self._build_callback_payload(ctx, message, trace_id)
         headers: Dict[str, str] = {
             "Content-Type": "application/json",
             "x-long-task-callback-token": callback_token,
@@ -595,10 +639,14 @@ class LongAction(Action, ABC):
         """Long-running logic. Must end with ctx.done().
 
         Use ``ctx.say(...)`` to emit any messages or structured payloads. In
-        callback mode, each ``ctx.say`` results in a callback JSON of the
-        form::
+        callback mode, each ``ctx.say`` results in a callback envelope with
+        explicit tracker events and control signals::
 
-            {"senderId": "...", "messages": [{...}]}
+            {"senderId": "...", "events": [{"event": "bot", ...}], "controls": []}
+
+        Lock/release signals are emitted separately as control payloads::
+
+            {"senderId": "...", "events": [], "controls": [{"type": "lock", ...}]}
 
         The return value is not sent to the frontend and is only for
         internal use by subclasses if needed.

--- a/tests/test_long_action_callback_payload.py
+++ b/tests/test_long_action_callback_payload.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    package = types.ModuleType(name)
+    package.__path__ = [str(path)]
+    sys.modules[name] = package
+
+
+def _load_module(module_name: str, relative_path: str):
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_ensure_package("src", _ROOT / "src")
+_ensure_package("src.actions", _ROOT / "src/actions")
+_ensure_package("src.actions.long_action", _ROOT / "src/actions/long_action")
+
+rasa_sdk_module = types.ModuleType("rasa_sdk")
+
+
+class _StubAction:
+    pass
+
+
+rasa_sdk_module.Action = _StubAction
+sys.modules.setdefault("rasa_sdk", rasa_sdk_module)
+
+_load_module("src.actions.long_action.long_action_registry", "src/actions/long_action/long_action_registry.py")
+long_action_context_module = _load_module(
+    "src.actions.long_action.long_action_context",
+    "src/actions/long_action/long_action_context.py",
+)
+long_action_module = _load_module(
+    "src.actions.long_action.long_action",
+    "src/actions/long_action/long_action.py",
+)
+
+LongAction = long_action_module.LongAction
+LongActionContext = long_action_context_module.LongActionContext
+
+
+class _FakeLongAction(LongAction):
+    def name(self) -> str:
+        return "fake_long_action"
+
+    async def work(self, ctx: LongActionContext) -> Any:
+        return None
+
+
+class LongActionCallbackPayloadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.action = _FakeLongAction()
+
+    def test_build_callback_payload_wraps_user_visible_message_as_tracker_event(self) -> None:
+        ctx = LongActionContext(sender_id="u1:thread:7", tracker_snapshot={})
+
+        payload = self.action._build_callback_payload(
+            ctx,
+            {
+                "text": "Hello there",
+                "custom": {"progress": "working"},
+                "buttons": [{"title": "Retry", "payload": "/retry"}],
+            },
+            trace_id="trace-123",
+        )
+
+        self.assertEqual(payload["senderId"], "u1:thread:7")
+        self.assertEqual(payload["controls"], [])
+        self.assertEqual(len(payload["events"]), 1)
+
+        event = payload["events"][0]
+        self.assertEqual(event["event"], "bot")
+        self.assertEqual(event["text"], "Hello there")
+        self.assertEqual(event["metadata"]["source"], "long-task-callback")
+        self.assertEqual(event["metadata"]["trace_id"], "trace-123")
+        self.assertEqual(event["data"]["custom"], {"progress": "working"})
+        self.assertEqual(event["data"]["buttons"], [{"title": "Retry", "payload": "/retry"}])
+
+    def test_build_callback_payload_emits_lock_as_control_signal(self) -> None:
+        ctx = LongActionContext(sender_id="u1:thread:7", tracker_snapshot={})
+        ctx._job_id = "job-abc"
+
+        payload = self.action._build_callback_payload(
+            ctx,
+            {"type": "lock"},
+            trace_id="trace-123",
+        )
+
+        self.assertEqual(payload["senderId"], "u1:thread:7")
+        self.assertEqual(payload["events"], [])
+        self.assertEqual(
+            payload["controls"],
+            [{
+                "type": "lock",
+                "jobId": "job-abc",
+                "scope": "long_action",
+                "source": "long-task-callback",
+                "traceId": "trace-123",
+            }],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR aligns Action long-task callback payloads with the current Webapp callback contract and hardens the callback boundary.

## Changes

- emit callback payloads using explicit `events` and `controls` envelopes
- send `lock` / `release` as control signals with `jobId`
- gate GraphQL debug text behind `ACTIONS_EMIT_QUERY_DEBUG`
- update stale long-action callback contract documentation
- add focused Action tests for callback payload generation
- include the current SSOT submodule bump