### PR TITLE
Enhance statistical test handling and improve callback alignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,15 +2,18 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
 
   - package-ecosystem: docker
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
 
   - package-ecosystem: pip
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly

--- a/src/actions/actions/guided_visualization_action.py
+++ b/src/actions/actions/guided_visualization_action.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 _ECHO_INTERNAL_ERRORS = env_util.env_flag("ACTIONS_ECHO_INTERNAL_ERRORS", default=False)
 _SHOW_EXECUTION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_EXECUTION_SUMMARY", default=True)
 _SHOW_NORMALIZATION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_NORMALIZATION_SUMMARY", default=True)
+_EMIT_QUERY_DEBUG = env_util.env_flag("ACTIONS_EMIT_QUERY_DEBUG", default=False)
 
 _executor_concurrency_raw = env_util.get_env("ACTIONS_EXECUTOR_MAX_CONCURRENCY", default="4") or "4"
 try:
@@ -138,7 +139,8 @@ class ActionGuidedGenerateVisualization(Action):  # pyright: ignore
                             "query": query_pretty,
                         }
                     )
-                    dispatcher.utter_message(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
+                    if _EMIT_QUERY_DEBUG:
+                        dispatcher.utter_message(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
 
                 plan_obj = build_guided_plan(slots=slots, user_sub=user_sub, trace_id=trace_id)
                 dispatcher.utter_message(

--- a/src/actions/actions/visualization_action.py
+++ b/src/actions/actions/visualization_action.py
@@ -37,6 +37,7 @@ _ECHO_INTERNAL_ERRORS = env_util.env_flag("ACTIONS_ECHO_INTERNAL_ERRORS", defaul
 _SHOW_EXECUTION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_EXECUTION_SUMMARY", default=True)
 _DEFER_CALLBACK_HANDOFF = env_util.env_flag("LONG_ACTION_DEFER_CALLBACK_HANDOFF", default=False)
 _SHOW_NORMALIZATION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_NORMALIZATION_SUMMARY", default=True)
+_EMIT_QUERY_DEBUG = env_util.env_flag("ACTIONS_EMIT_QUERY_DEBUG", default=False)
 _VISUALIZATION_CONTINUATION_INTENTS = {
     "generate_visualization",
     "update_visualization",
@@ -935,7 +936,8 @@ class ActionOneShotGenerateVisualization(LongAction):
                             "query": query_pretty,
                         }
                     )
-                    ctx.say(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
+                    if _EMIT_QUERY_DEBUG:
+                        ctx.say(text=(f"[dev] GraphQL query\nhash={payload.get('query_hash') or '-'}\n{query_pretty}"))
 
                 # In deferred-handoff mode, initial routing/clarification can use
                 # normal dispatcher delivery and heavy generation streams via

--- a/src/actions/long_action/long_action.py
+++ b/src/actions/long_action/long_action.py
@@ -330,6 +330,54 @@ class LongAction(Action, ABC):
     def _release_message() -> Dict[str, str]:
         return {"type": "release"}
 
+    @staticmethod
+    def _is_control_message(message: Dict[str, Any]) -> bool:
+        """Return True if this is a lock/release control signal, not a user-visible message."""
+        return message.get("type") in {"lock", "release"}
+
+    @staticmethod
+    def _message_to_tracker_event(message: Dict[str, Any], trace_id: Optional[str] = None) -> Dict[str, Any]:
+        """Convert a ctx.say kwargs dict to a tracker bot event shape."""
+        event: Dict[str, Any] = {
+            "event": "bot",
+            "metadata": {
+                "source": "long-task-callback",
+                **(({"trace_id": trace_id}) if isinstance(trace_id, str) and trace_id.strip() else {}),
+            },
+        }
+        if isinstance(message.get("text"), str):
+            event["text"] = message["text"]
+        custom = message.get("custom")
+        if custom and isinstance(custom, dict):
+            event["data"] = {"custom": custom}
+        buttons = message.get("buttons")
+        if buttons and isinstance(buttons, list):
+            event["data"] = {**(event.get("data") or {}), "buttons": buttons}
+        return event
+
+    def _build_callback_payload(
+        self,
+        ctx: "LongActionContext",
+        message: Dict[str, Any],
+        trace_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build the callback payload in the events/controls envelope format."""
+        payload: Dict[str, Any] = {"senderId": ctx.sender_id}
+        if self._is_control_message(message):
+            job_id = getattr(ctx, "_job_id", None) or ""
+            payload["controls"] = [{
+                "type": message["type"],
+                "jobId": job_id,
+                "scope": "long_action",
+                "source": "long-task-callback",
+                **(({"traceId": trace_id}) if isinstance(trace_id, str) and trace_id.strip() else {}),
+            }]
+            payload["events"] = []
+        else:
+            payload["events"] = [self._message_to_tracker_event(message, trace_id)]
+            payload["controls"] = []
+        return payload
+
     async def prework(self, ctx: LongActionContext) -> PreworkResult:
         """Optional in-band phase before work() starts.
 
@@ -390,10 +438,8 @@ class LongAction(Action, ABC):
             job_id = uuid.uuid4().hex
 
             if _DEFER_CALLBACK_HANDOFF:
-                # Optional hybrid mode: start in normal dispatcher path and let the
-                # action explicitly switch to callback transport via
-                # ctx.enable_callback_mode().
                 ctx = LongActionContext(sender_id=sender_id, tracker_snapshot=tracker_snapshot, dispatcher=dispatcher)
+                ctx._job_id = job_id
                 ctx.attach_progress_callback(
                     lambda message, ctx=ctx, job_id=job_id, callback_url=callback_url, callback_token=callback_token: self._post_progress(
                         ctx,
@@ -424,6 +470,7 @@ class LongAction(Action, ABC):
                 return [*immediate_events, *ctx.pending_events]
 
             ctx = LongActionContext(sender_id=sender_id, tracker_snapshot=tracker_snapshot)
+            ctx._job_id = job_id
 
             # In callback mode, stream every ctx.say() as a progress callback to
             # the frontend while the job is running.
@@ -456,20 +503,17 @@ class LongAction(Action, ABC):
     ) -> None:
         """Send a callback for a single ctx.say() message.
 
-        The payload shape is kept intentionally simple and dispatcher-like so
-        the frontend can treat it similarly to Rasa messages:
+        Payload envelope:
+        - Real messages go in ``events`` as tracker bot-event objects.
+        - Lock/release control signals go in ``controls`` as control objects.
 
-        {
-            "senderId": "...",
-            "messages": [ { ...ctx.say kwargs... } ]
-        }
+        {"senderId": ..., "events": [{"event": "bot", ...}], "controls": []}
+        or
+        {"senderId": ..., "events": [], "controls": [{"type": "lock|release", ...}]}
         """
 
-        payload: Dict[str, Any] = {
-            "senderId": ctx.sender_id,
-            "messages": [message],
-        }
         trace_id = _resolve_progress_trace_id(ctx, message)
+        payload: Dict[str, Any] = self._build_callback_payload(ctx, message, trace_id)
         headers: Dict[str, str] = {
             "Content-Type": "application/json",
             "x-long-task-callback-token": callback_token,
@@ -595,10 +639,14 @@ class LongAction(Action, ABC):
         """Long-running logic. Must end with ctx.done().
 
         Use ``ctx.say(...)`` to emit any messages or structured payloads. In
-        callback mode, each ``ctx.say`` results in a callback JSON of the
-        form::
+        callback mode, each ``ctx.say`` results in a callback envelope with
+        explicit tracker events and control signals::
 
-            {"senderId": "...", "messages": [{...}]}
+            {"senderId": "...", "events": [{"event": "bot", ...}], "controls": []}
+
+        Lock/release signals are emitted separately as control payloads::
+
+            {"senderId": "...", "events": [], "controls": [{"type": "lock", ...}]}
 
         The return value is not sent to the frontend and is only for
         internal use by subclasses if needed.

--- a/src/executors/orchestration/plan_executor.py
+++ b/src/executors/orchestration/plan_executor.py
@@ -11,9 +11,13 @@ from src.domain.dto.analytics import StatisticalTestResult
 from src.domain.dto.charts.types import ChartAxis, ChartSeries
 from src.domain.dto.execution_summary import ExecutionBatchSummary, ExecutionSummary
 from src.domain.dto.response import VisualizationResponse
+from src.domain.graphql.request import BooleanFilter as GQLBooleanFilter
 from src.domain.graphql.request import DataOrigin, TimePeriod
 from src.domain.graphql.request import DateFilter as GQLDateFilter
+from src.domain.graphql.request import IntegerFilter as GQLIntegerFilter
 from src.domain.graphql.request import LogicalFilter as GQLLogicalFilter
+from src.domain.graphql.request import SexFilter as GQLSexFilter
+from src.domain.graphql.request import StrokeFilter as GQLStrokeFilter
 from src.domain.langchain.schema import AnalysisPlan, GroupBySpec, StatisticalTestSpec
 from src.executors.graphql.client import GraphQLProxyClient
 from src.executors.mapping.chart_builder import build_chart_dto
@@ -55,11 +59,19 @@ logger = logging.getLogger(__name__)
 # Privacy/safety defaults:
 # - Avoid logging raw GraphQL queries by default.
 _LOG_GRAPHQL_QUERY = env_util.env_flag("EXECUTOR_LOG_GRAPHQL_QUERY", default=False)
-_EMIT_COMPILER_DIAGNOSTICS = env_util.env_flag("EXECUTOR_EMIT_COMPILER_DIAGNOSTICS", default=False)
-_ENABLE_UNBATCHED_TIME_FALLBACK = env_util.env_flag("EXECUTOR_ENABLE_UNBATCHED_TIME_FALLBACK", default=True)
-_STRICT_MODE = env_util.env_flag("ANALYTICS_STRICT_MODE", default=False) or env_util.env_flag("EXECUTOR_STRICT_MODE", default=False)
+_EMIT_COMPILER_DIAGNOSTICS = env_util.env_flag(
+    "EXECUTOR_EMIT_COMPILER_DIAGNOSTICS", default=False
+)
+_ENABLE_UNBATCHED_TIME_FALLBACK = env_util.env_flag(
+    "EXECUTOR_ENABLE_UNBATCHED_TIME_FALLBACK", default=True
+)
+_STRICT_MODE = env_util.env_flag(
+    "ANALYTICS_STRICT_MODE", default=False
+) or env_util.env_flag("EXECUTOR_STRICT_MODE", default=False)
 
-_executor_default_concurrency_raw = env_util.get_env("EXECUTOR_DEFAULT_MAX_CONCURRENCY", default="4") or "4"
+_executor_default_concurrency_raw = (
+    env_util.get_env("EXECUTOR_DEFAULT_MAX_CONCURRENCY", default="4") or "4"
+)
 try:
     _executor_default_concurrency = max(1, int(_executor_default_concurrency_raw))
 except Exception:
@@ -79,7 +91,9 @@ except Exception:
     _executor_default_concurrency = 4
 _EXECUTOR_DEFAULT_MAX_CONCURRENCY = _executor_default_concurrency
 
-_executor_sync_concurrency_raw = env_util.get_env("EXECUTOR_SYNC_MAX_CONCURRENCY", default="1") or "1"
+_executor_sync_concurrency_raw = (
+    env_util.get_env("EXECUTOR_SYNC_MAX_CONCURRENCY", default="1") or "1"
+)
 try:
     _executor_sync_concurrency = max(1, int(_executor_sync_concurrency_raw))
 except Exception:
@@ -99,10 +113,14 @@ except Exception:
     _executor_sync_concurrency = 1
 _EXECUTOR_SYNC_MAX_CONCURRENCY = _executor_sync_concurrency
 
-proxy_url, action_server_token = env_util.require_all_env("RASA_PROXY_URL", "ACTION_SERVER_TOKEN")
+proxy_url, action_server_token = env_util.require_all_env(
+    "RASA_PROXY_URL", "ACTION_SERVER_TOKEN"
+)
 graphql_target = env_util.require_any_env("RASA_PROXY_GRAPHQL_TARGET")
 
-_graphql_timeout_raw = env_util.get_env("EXECUTOR_GRAPHQL_TIMEOUT_SECONDS", default="30") or "30"
+_graphql_timeout_raw = (
+    env_util.get_env("EXECUTOR_GRAPHQL_TIMEOUT_SECONDS", default="30") or "30"
+)
 try:
     _graphql_timeout_seconds = max(5, int(float(_graphql_timeout_raw)))
 except Exception:
@@ -111,7 +129,9 @@ except Exception:
 client = GraphQLProxyClient(
     proxy_url=proxy_url,
     action_server_token=action_server_token,
-    target=graphql_target if isinstance(graphql_target, str) and graphql_target.strip() else "graphql",
+    target=graphql_target
+    if isinstance(graphql_target, str) and graphql_target.strip()
+    else "graphql",
     timeout_seconds=_graphql_timeout_seconds,
     connect_timeout_seconds=5,
     max_total_timeout_seconds=_graphql_timeout_seconds + 5,
@@ -201,8 +221,12 @@ def _parse_int_csv(raw: str) -> List[int]:
     return out
 
 
-_DEFAULT_PROVIDER_GROUP_IDS = _parse_int_csv(env_util.get_env("EXECUTOR_DEFAULT_PROVIDER_GROUP_IDS", default="1") or "1")
-_DEFAULT_PROVIDER_IDS = _parse_int_csv(env_util.get_env("EXECUTOR_DEFAULT_PROVIDER_IDS", default="") or "")
+_DEFAULT_PROVIDER_GROUP_IDS = _parse_int_csv(
+    env_util.get_env("EXECUTOR_DEFAULT_PROVIDER_GROUP_IDS", default="1") or "1"
+)
+_DEFAULT_PROVIDER_IDS = _parse_int_csv(
+    env_util.get_env("EXECUTOR_DEFAULT_PROVIDER_IDS", default="") or ""
+)
 
 
 def _build_default_data_origin() -> DataOrigin:
@@ -257,12 +281,103 @@ def _default_time_period_from_filter(filter_obj: Optional[Any]) -> Dict[str, str
     }
 
 
-def _merge_case_filters(base_filter: Optional[Any], cohort_filter: Optional[Any]) -> Optional[Any]:
+def _merge_case_filters(
+    base_filter: Optional[Any], cohort_filter: Optional[Any]
+) -> Optional[Any]:
     if base_filter is None:
         return cohort_filter
     if cohort_filter is None:
         return base_filter
     return GQLLogicalFilter(operator="AND", children=[base_filter, cohort_filter])
+
+
+# Adaptation layer for GraphQL filter objects to the statistical test payload format. This is necessary because the GraphQL API expects a specific structure for filters.
+def _serialize_case_filter_input(filter_obj: Optional[Any]) -> Optional[Dict[str, Any]]:
+    if filter_obj is None:
+        return None
+
+    if isinstance(filter_obj, GQLLogicalFilter):
+        children: List[Dict[str, Any]] = []
+        for child in filter_obj.children:
+            child_serialized = _serialize_case_filter_input(child)
+            if child_serialized is not None:
+                children.append(child_serialized)
+        return {
+            "node": {
+                "logicalOperator": str(filter_obj.operator),
+                "children": children,
+            }
+        }
+
+    if isinstance(filter_obj, GQLIntegerFilter):
+        return {
+            "leaf": {
+                "integerCaseFilter": {
+                    "property": filter_obj.property,
+                    "operator": filter_obj.operator.value,
+                    "value": int(filter_obj.value),
+                }
+            }
+        }
+
+    if isinstance(filter_obj, GQLBooleanFilter):
+        return {
+            "leaf": {
+                "booleanCaseFilter": {
+                    "property": str(filter_obj.property),
+                    "value": bool(filter_obj.value),
+                }
+            }
+        }
+
+    if isinstance(filter_obj, GQLSexFilter):
+        return {
+            "leaf": {
+                "enumCaseFilter": {
+                    "sexType": {
+                        "values": [filter_obj.sex_type.value],
+                        "contains": bool(filter_obj.contains),
+                    }
+                }
+            }
+        }
+
+    if isinstance(filter_obj, GQLStrokeFilter):
+        return {
+            "leaf": {
+                "enumCaseFilter": {
+                    "strokeType": {
+                        "values": [filter_obj.stroke_type.value],
+                        "contains": bool(filter_obj.contains),
+                    }
+                }
+            }
+        }
+
+    if isinstance(filter_obj, GQLDateFilter):
+        return {
+            "leaf": {
+                "dateCaseFilter": {
+                    "property": filter_obj.property,
+                    "operator": filter_obj.operator.value,
+                    "value": filter_obj.value,
+                }
+            }
+        }
+
+    logger.warning(
+        "[plan_executor] Unsupported case filter type for statistical test payload: %s",
+        type(filter_obj).__name__,
+        extra={
+            "log_context": {
+                "event": "plan_executor.statistical_test.unsupported_case_filter",
+                "operation": "_serialize_case_filter_input",
+                "outcome": "degraded",
+                "filter_type": type(filter_obj).__name__,
+            }
+        },
+    )
+    return None
 
 
 def _cohort_split_from_groupby(
@@ -292,16 +407,57 @@ def _cohort_split_from_groupby(
     return None
 
 
-def _execute_mann_whitney_test(test: StatisticalTestSpec, user_sub: str, trace_id: str) -> List[StatisticalTestResult]:
-    base_filter = to_gql_filter(test.filters)
+def _has_distinct_metric_cohorts(
+    metric_a: Optional[Any], metric_b: Optional[Any]
+) -> bool:
+    if metric_a is None or metric_b is None:
+        return False
 
-    metrics = test.metrics or []
+    metric_a_origin = getattr(metric_a, "data_origin", None)
+    metric_b_origin = getattr(metric_b, "data_origin", None)
+    metric_a_scope = getattr(metric_a, "origin_scope", None)
+    metric_b_scope = getattr(metric_b, "origin_scope", None)
+
+    if metric_a_origin is None or metric_b_origin is None:
+        return False
+
+    origin_a_payload = metric_a_origin.model_dump(by_alias=True, exclude_none=True)
+    origin_b_payload = metric_b_origin.model_dump(by_alias=True, exclude_none=True)
+    if origin_a_payload != origin_b_payload:
+        return True
+
+    if metric_a_scope is None or metric_b_scope is None:
+        return False
+
+    scope_a_payload = metric_a_scope.model_dump(by_alias=True, exclude_none=True)
+    scope_b_payload = metric_b_scope.model_dump(by_alias=True, exclude_none=True)
+    if scope_a_payload != scope_b_payload:
+        return True
+
+    label_a = getattr(metric_a_scope, "label", None)
+    label_b = getattr(metric_b_scope, "label", None)
+    if isinstance(label_a, str) and isinstance(label_b, str):
+        return bool(
+            label_a.strip() and label_b.strip() and label_a.strip() != label_b.strip()
+        )
+
+    return False
+
+
+def _translate_mann_whitney_metrics(
+    metrics: List[Any], trace_id: str
+) -> tuple[List[str], Optional[StatisticalTestResult]]:
+    # Convert planner metric codes to backend enum values once for all MW paths.
     metric_values = [metric.metric for metric in metrics if metric.metric.strip()]
     if not metric_values:
-        return []
+        return [], StatisticalTestResult(
+            test_type="MANN_WHITNEY_U_TEST",
+            status="skipped",
+            reason="No metric was provided for statistical testing",
+            title="Mann-Whitney U Test: skipped",
+            details={"trace_id": trace_id},
+        )
 
-    # Translate SSOT canonical names to StatisticsMetricEnum GQL values and
-    # validate that each metric is supported by the statistics endpoint.
     stats_enum_map = get_statistics_metric_enum_map()
     translated_metrics: List[str] = []
     ineligible: List[str] = []
@@ -312,7 +468,9 @@ def _execute_mann_whitney_test(test: StatisticalTestSpec, user_sub: str, trace_i
         else:
             translated_metrics.append(gql_name)
     if ineligible:
-        reason = f"Metric(s) not supported for statistical testing: {', '.join(ineligible)}"
+        reason = (
+            f"Metric(s) not supported for statistical testing: {', '.join(ineligible)}"
+        )
         logger.warning(
             "[plan_executor] Skipping MANN_WHITNEY_U_TEST: %s",
             reason,
@@ -320,22 +478,334 @@ def _execute_mann_whitney_test(test: StatisticalTestSpec, user_sub: str, trace_i
                 "log_context": {
                     "trace_id": trace_id or "-",
                     "event": "plan_executor.statistical_test.skipped_ineligible_metrics",
-                    "operation": "_execute_mann_whitney_test",
+                    "operation": "_translate_mann_whitney_metrics",
                     "outcome": "degraded",
                     "test_type": "MANN_WHITNEY_U_TEST",
                     "ineligible_metric_count": len(ineligible),
                 }
             },
         )
+        return [], StatisticalTestResult(
+            test_type="MANN_WHITNEY_U_TEST",
+            status="skipped",
+            reason=reason,
+            title="Mann-Whitney U Test: skipped",
+            details={"trace_id": trace_id},
+        )
+
+    return translated_metrics, None
+
+
+def _label_from_date_bounds(
+    start_date: Optional[str], end_date: Optional[str], fallback: str
+) -> str:
+    if not start_date or not end_date:
+        return fallback
+    quarter_lookup = {
+        ("01-01", "03-31"): "Q1",
+        ("04-01", "06-30"): "Q2",
+        ("07-01", "09-30"): "Q3",
+        ("10-01", "12-31"): "Q4",
+    }
+    if len(start_date) >= 10 and len(end_date) >= 10 and start_date[:4] == end_date[:4]:
+        quarter = quarter_lookup.get((start_date[5:10], end_date[5:10]))
+        if quarter is not None:
+            return f"{quarter} {start_date[:4]}"
+    return f"{start_date} to {end_date}"
+
+
+def _execute_mann_whitney_query(
+    *,
+    metric_values: List[str],
+    user_sub: str,
+    trace_id: str,
+    label_a: str,
+    label_b: str,
+    data_origin_payload_a: Dict[str, Any],
+    data_origin_payload_b: Dict[str, Any],
+    time_period_payload_a: Dict[str, str],
+    time_period_payload_b: Dict[str, str],
+    cohort_filter_a: Optional[Any],
+    cohort_filter_b: Optional[Any],
+) -> List[StatisticalTestResult]:
+    # Shared GraphQL execution path for both standard and temporal MW comparisons.
+    query = """
+query MannWhitney($metric: [StatisticsMetricEnum!]!, $cohortA: CohortFilterInput!, $cohortB: CohortFilterInput!) {
+  getMannWhitneyUTest(metric: $metric, cohortA: $cohortA, cohortB: $cohortB) {
+    metric
+    uStatistic
+    pValue
+    significant
+    cohortA { size median }
+    cohortB { size median }
+  }
+}
+    """.strip()
+
+    variables: Dict[str, Any] = {
+        "metric": metric_values,
+        "cohortA": {
+            "dataOrigin": data_origin_payload_a,
+            "timePeriod": time_period_payload_a,
+            "caseFilter": _serialize_case_filter_input(cohort_filter_a),
+        },
+        "cohortB": {
+            "dataOrigin": data_origin_payload_b,
+            "timePeriod": time_period_payload_b,
+            "caseFilter": _serialize_case_filter_input(cohort_filter_b),
+        },
+    }
+
+    payload = client.query_raw(
+        query_str=query,
+        user_sub=user_sub,
+        variables=variables,
+        trace_id=trace_id,
+        raise_on_error=False,
+    )
+    if payload is None:
         return [
             StatisticalTestResult(
                 test_type="MANN_WHITNEY_U_TEST",
                 status="skipped",
-                reason=reason,
+                reason="Mann-Whitney endpoint returned no payload",
                 title="Mann-Whitney U Test: skipped",
+                details={"trace_id": trace_id},
             )
         ]
-    metric_values = translated_metrics
+
+    payload_errors_any = payload.get("errors")
+    if isinstance(payload_errors_any, list) and payload_errors_any:
+        payload_errors = cast(List[Any], payload_errors_any)
+        first_error = payload_errors[0]
+        if isinstance(first_error, dict):
+            first_error_dict = cast(Dict[str, Any], first_error)
+            error_message = str(
+                first_error_dict.get("message") or "GraphQL returned an error"
+            )
+        else:
+            error_message = str(first_error)
+        return [
+            StatisticalTestResult(
+                test_type="MANN_WHITNEY_U_TEST",
+                status="error",
+                reason=error_message,
+                title="Mann-Whitney U Test: error",
+                details={"trace_id": trace_id},
+            )
+        ]
+
+    data = _mapping_to_dict(payload.get("data"))
+    if not data:
+        return [
+            StatisticalTestResult(
+                test_type="MANN_WHITNEY_U_TEST",
+                status="skipped",
+                reason="Mann-Whitney endpoint returned empty data",
+                title="Mann-Whitney U Test: skipped",
+                details={"trace_id": trace_id},
+            )
+        ]
+
+    rows_raw: Any = data.get("getMannWhitneyUTest")
+    if isinstance(rows_raw, dict):
+        rows_raw = [rows_raw]
+    if not isinstance(rows_raw, list):
+        return [
+            StatisticalTestResult(
+                test_type="MANN_WHITNEY_U_TEST",
+                status="error",
+                reason="Mann-Whitney response shape is invalid",
+                title="Mann-Whitney U Test: error",
+                details={"trace_id": trace_id},
+            )
+        ]
+
+    out: List[StatisticalTestResult] = []
+    rows = cast(List[object], rows_raw)
+    for row_any in rows:
+        if not isinstance(row_any, dict):
+            continue
+        row = cast(Dict[str, Any], row_any)
+
+        p_value_any = row.get("pValue")
+        p_value: Optional[float]
+        if isinstance(p_value_any, (int, float)):
+            p_value = float(p_value_any)
+        else:
+            p_value = None
+
+        u_stat_any = row.get("uStatistic")
+        u_stat = float(u_stat_any) if isinstance(u_stat_any, (int, float)) else None
+        significant_any = row.get("significant")
+        significant = (
+            bool(significant_any) if isinstance(significant_any, bool) else None
+        )
+
+        cohort_a = cast(Dict[str, Any], row.get("cohortA") or {})
+        cohort_b = cast(Dict[str, Any], row.get("cohortB") or {})
+
+        metric_name = row.get("metric")
+        metric_label = str(metric_name) if isinstance(metric_name, str) else "UNKNOWN"
+
+        out.append(
+            StatisticalTestResult(
+                test_type="MANN_WHITNEY_U_TEST",
+                status="success",
+                p_value=p_value,
+                passed=significant,
+                title=f"Mann-Whitney U Test: {metric_label}",
+                details={
+                    "trace_id": trace_id,
+                    "metric": metric_label,
+                    "u_statistic": u_stat,
+                    "cohort_a_label": label_a,
+                    "cohort_b_label": label_b,
+                    "cohort_a_size": cohort_a.get("size"),
+                    "cohort_b_size": cohort_b.get("size"),
+                    "cohort_a_median": cohort_a.get("median"),
+                    "cohort_b_median": cohort_b.get("median"),
+                },
+            )
+        )
+
+    if not out:
+        return [
+            StatisticalTestResult(
+                test_type="MANN_WHITNEY_U_TEST",
+                status="skipped",
+                reason="Mann-Whitney returned no comparable cohort rows",
+                title="Mann-Whitney U Test: skipped",
+                details={"trace_id": trace_id},
+            )
+        ]
+
+    return out
+
+
+def _can_pair_temporal_mann_whitney_tests(
+    test_a: StatisticalTestSpec, test_b: StatisticalTestSpec
+) -> bool:
+    if test_a.group_by is not None or test_b.group_by is not None:
+        return False
+    if test_a.filters is None or test_b.filters is None:
+        return False
+
+    metrics_a = [
+        m.metric.strip().upper()
+        for m in (test_a.metrics or [])
+        if m.metric and m.metric.strip()
+    ]
+    metrics_b = [
+        m.metric.strip().upper()
+        for m in (test_b.metrics or [])
+        if m.metric and m.metric.strip()
+    ]
+    if not metrics_a or not metrics_b:
+        return False
+    return metrics_a == metrics_b
+
+
+def _execute_temporal_pair_mann_whitney(
+    test_a: StatisticalTestSpec,
+    test_b: StatisticalTestSpec,
+    user_sub: str,
+    trace_id: str,
+) -> List[StatisticalTestResult]:
+    metrics = list(test_a.metrics or [])
+    metric_values, metric_error = _translate_mann_whitney_metrics(metrics, trace_id)
+    if metric_error is not None:
+        return [metric_error]
+
+    metric_a = metrics[0] if len(metrics) > 0 else None
+    metric_b = metrics[1] if len(metrics) > 1 else None
+    shared_origin = (
+        (metric_a.data_origin if metric_a is not None else None)
+        or (metric_b.data_origin if metric_b is not None else None)
+        or _build_default_data_origin()
+    )
+    data_origin_payload = cast(Any, shared_origin).model_dump(
+        by_alias=True, exclude_none=True
+    )
+
+    filter_a = to_gql_filter(test_a.filters)
+    filter_b = to_gql_filter(test_b.filters)
+
+    start_a, end_a = _collect_date_bounds(filter_a)
+    start_b, end_b = _collect_date_bounds(filter_b)
+    label_a = _label_from_date_bounds(start_a, end_a, "Cohort A")
+    label_b = _label_from_date_bounds(start_b, end_b, "Cohort B")
+
+    shared_start_candidates = [
+        candidate for candidate in [start_a, start_b] if candidate
+    ]
+    shared_end_candidates = [candidate for candidate in [end_a, end_b] if candidate]
+    if shared_start_candidates and shared_end_candidates:
+        shared_time_period = {
+            "startDate": min(shared_start_candidates),
+            "endDate": max(shared_end_candidates),
+        }
+    else:
+        shared_time_period = _default_time_period_from_filter(None)
+
+    return _execute_mann_whitney_query(
+        metric_values=metric_values,
+        user_sub=user_sub,
+        trace_id=trace_id,
+        label_a=label_a,
+        label_b=label_b,
+        data_origin_payload_a=data_origin_payload,
+        data_origin_payload_b=data_origin_payload,
+        time_period_payload_a=shared_time_period,
+        time_period_payload_b=shared_time_period,
+        cohort_filter_a=filter_a,
+        cohort_filter_b=filter_b,
+    )
+
+
+def _statistical_result_signature(result: StatisticalTestResult) -> tuple[Any, ...]:
+    details = result.details or {}
+    return (
+        result.test_type,
+        result.status,
+        result.reason,
+        result.title,
+        result.p_value,
+        result.passed,
+        details.get("metric"),
+        details.get("cohort_a_label"),
+        details.get("cohort_b_label"),
+        details.get("cohort_a_size"),
+        details.get("cohort_b_size"),
+        details.get("cohort_a_median"),
+        details.get("cohort_b_median"),
+        details.get("u_statistic"),
+    )
+
+
+def _dedupe_statistical_results(
+    results: List[StatisticalTestResult],
+) -> List[StatisticalTestResult]:
+    deduped: List[StatisticalTestResult] = []
+    seen: set[tuple[Any, ...]] = set()
+    for result in results:
+        signature = _statistical_result_signature(result)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        deduped.append(result)
+    return deduped
+
+
+def _execute_mann_whitney_test(
+    test: StatisticalTestSpec, user_sub: str, trace_id: str
+) -> List[StatisticalTestResult]:
+    base_filter = to_gql_filter(test.filters)
+
+    metrics = test.metrics or []
+    metric_values, metric_error = _translate_mann_whitney_metrics(metrics, trace_id)
+    if metric_error is not None:
+        return [metric_error]
 
     # Preferred path: explicitly scoped metric pair (hospital-vs-hospital,
     # hospital-vs-national, etc.) where first two metric entries define cohorts.
@@ -353,12 +823,22 @@ def _execute_mann_whitney_test(test: StatisticalTestSpec, user_sub: str, trace_i
     cohort_filter_a = base_filter
     cohort_filter_b = base_filter
 
-    if metric_a_origin is not None and metric_b_origin is not None:
-        data_origin_payload_a = metric_a_origin.model_dump(by_alias=True, exclude_none=True)
-        data_origin_payload_b = metric_b_origin.model_dump(by_alias=True, exclude_none=True)
-        if metric_a_scope is not None and metric_a_scope.label and metric_a_scope.label.strip():
+    if _has_distinct_metric_cohorts(metric_a, metric_b):
+        origin_a = cast(Any, metric_a_origin)
+        origin_b = cast(Any, metric_b_origin)
+        data_origin_payload_a = origin_a.model_dump(by_alias=True, exclude_none=True)
+        data_origin_payload_b = origin_b.model_dump(by_alias=True, exclude_none=True)
+        if (
+            metric_a_scope is not None
+            and metric_a_scope.label
+            and metric_a_scope.label.strip()
+        ):
             label_a = metric_a_scope.label.strip()
-        if metric_b_scope is not None and metric_b_scope.label and metric_b_scope.label.strip():
+        if (
+            metric_b_scope is not None
+            and metric_b_scope.label
+            and metric_b_scope.label.strip()
+        ):
             label_b = metric_b_scope.label.strip()
     else:
         # Backward-compatible fallback: derive cohorts from two-way group_by split.
@@ -390,117 +870,73 @@ def _execute_mann_whitney_test(test: StatisticalTestSpec, user_sub: str, trace_i
         dim, cat_a, cat_b, label_a_split, label_b_split = cohort_split
         cohort_filter_a = _merge_case_filters(base_filter, dim.filter_for(cat_a))
         cohort_filter_b = _merge_case_filters(base_filter, dim.filter_for(cat_b))
-        data_origin_payload_default = _build_default_data_origin().model_dump(by_alias=True, exclude_none=True)
+        shared_origin = (
+            metric_a_origin or metric_b_origin or _build_default_data_origin()
+        )
+        data_origin_payload_default = cast(Any, shared_origin).model_dump(
+            by_alias=True, exclude_none=True
+        )
         data_origin_payload_a = data_origin_payload_default
         data_origin_payload_b = data_origin_payload_default
         label_a = label_a_split
         label_b = label_b_split
 
     time_period_payload = _default_time_period_from_filter(base_filter)
-
-    query = """
-query MannWhitney($metric: [StatisticsMetricEnum!]!, $cohortA: CohortFilterInput!, $cohortB: CohortFilterInput!) {
-  getMannWhitneyUTest(metric: $metric, cohortA: $cohortA, cohortB: $cohortB) {
-    metric
-    uStatistic
-    pValue
-    significant
-    cohortA { size median }
-    cohortB { size median }
-  }
-}
-    """.strip()
-
-    variables: Dict[str, Any] = {
-        "metric": metric_values,
-        "cohortA": {
-            "dataOrigin": data_origin_payload_a,
-            "timePeriod": time_period_payload,
-            "caseFilter": cohort_filter_a.model_dump(by_alias=True, exclude_none=True) if cohort_filter_a is not None else None,
-        },
-        "cohortB": {
-            "dataOrigin": data_origin_payload_b,
-            "timePeriod": time_period_payload,
-            "caseFilter": cohort_filter_b.model_dump(by_alias=True, exclude_none=True) if cohort_filter_b is not None else None,
-        },
-    }
-
-    payload = client.query_raw(
-        query_str=query,
-        user_sub=user_sub,
-        variables=variables,
-        trace_id=trace_id,
-        raise_on_error=False,
+    origin_a = data_origin_payload_a or _build_default_data_origin().model_dump(
+        by_alias=True, exclude_none=True
     )
-    if payload is None:
-        return []
-
-    data = _mapping_to_dict(payload.get("data"))
-    if not data:
-        return []
-
-    rows_any = data.get("getMannWhitneyUTest")
-    if not isinstance(rows_any, list):
-        return []
-
-    out: List[StatisticalTestResult] = []
-    rows = cast(List[object], rows_any)
-    for row_any in rows:
-        if not isinstance(row_any, dict):
-            continue
-        row = cast(Dict[str, Any], row_any)
-
-        p_value_any = row.get("pValue")
-        p_value: Optional[float]
-        if isinstance(p_value_any, (int, float)):
-            p_value = float(p_value_any)
-        else:
-            p_value = None
-
-        u_stat_any = row.get("uStatistic")
-        u_stat = float(u_stat_any) if isinstance(u_stat_any, (int, float)) else None
-        significant_any = row.get("significant")
-        significant = bool(significant_any) if isinstance(significant_any, bool) else None
-
-        cohort_a = cast(Dict[str, Any], row.get("cohortA") or {})
-        cohort_b = cast(Dict[str, Any], row.get("cohortB") or {})
-
-        metric_name = row.get("metric")
-        metric_label = str(metric_name) if isinstance(metric_name, str) else "UNKNOWN"
-
-        out.append(
-            StatisticalTestResult(
-                test_type="MANN_WHITNEY_U_TEST",
-                status="success",
-                p_value=p_value,
-                passed=significant,
-                title=f"Mann-Whitney U Test: {metric_label}",
-                details={
-                    "trace_id": trace_id,
-                    "metric": metric_label,
-                    "u_statistic": u_stat,
-                    "cohort_a_label": label_a,
-                    "cohort_b_label": label_b,
-                    "cohort_a_size": cohort_a.get("size"),
-                    "cohort_b_size": cohort_b.get("size"),
-                    "cohort_a_median": cohort_a.get("median"),
-                    "cohort_b_median": cohort_b.get("median"),
-                },
-            )
-        )
-
-    return out
+    origin_b = data_origin_payload_b or _build_default_data_origin().model_dump(
+        by_alias=True, exclude_none=True
+    )
+    return _execute_mann_whitney_query(
+        metric_values=metric_values,
+        user_sub=user_sub,
+        trace_id=trace_id,
+        label_a=label_a,
+        label_b=label_b,
+        data_origin_payload_a=origin_a,
+        data_origin_payload_b=origin_b,
+        time_period_payload_a=time_period_payload,
+        time_period_payload_b=time_period_payload,
+        cohort_filter_a=cohort_filter_a,
+        cohort_filter_b=cohort_filter_b,
+    )
 
 
-def _execute_statistical_tests(plan: AnalysisPlan, user_sub: str, trace_id: str) -> List[StatisticalTestResult]:
+def _execute_statistical_tests(
+    plan: AnalysisPlan, user_sub: str, trace_id: str
+) -> List[StatisticalTestResult]:
     tests = plan.statistical_tests or []
     results: List[StatisticalTestResult] = []
 
-    for test in tests:
+    index = 0
+    while index < len(tests):
+        test = tests[index]
         test_type = (test.test_type or "").upper().strip()
         try:
             if test_type == "MANN_WHITNEY_U_TEST":
-                results.extend(_execute_mann_whitney_test(test=test, user_sub=user_sub, trace_id=trace_id))
+                if index + 1 < len(tests):
+                    next_test = tests[index + 1]
+                    next_type = (next_test.test_type or "").upper().strip()
+                    if (
+                        next_type == "MANN_WHITNEY_U_TEST"
+                        and _can_pair_temporal_mann_whitney_tests(test, next_test)
+                    ):
+                        results.extend(
+                            _execute_temporal_pair_mann_whitney(
+                                test_a=test,
+                                test_b=next_test,
+                                user_sub=user_sub,
+                                trace_id=trace_id,
+                            )
+                        )
+                        index += 2
+                        continue
+                results.extend(
+                    _execute_mann_whitney_test(
+                        test=test, user_sub=user_sub, trace_id=trace_id
+                    )
+                )
             else:
                 logger.warning(
                     "[plan_executor] Statistical test type '%s' is not implemented yet",
@@ -529,11 +965,14 @@ def _execute_statistical_tests(plan: AnalysisPlan, user_sub: str, trace_id: str)
                     }
                 },
             )
+        index += 1
 
     return results
 
 
-def _emit_compiler_diagnostics(progress_cb: Optional[Callable[[str], None]], payload: Dict[str, Any], trace_id: str) -> None:
+def _emit_compiler_diagnostics(
+    progress_cb: Optional[Callable[[str], None]], payload: Dict[str, Any], trace_id: str
+) -> None:
     log_context_fields: Dict[str, Any] = {
         "trace_id": trace_id,
         "event": "plan_executor.compiler_diagnostics",
@@ -546,7 +985,9 @@ def _emit_compiler_diagnostics(progress_cb: Optional[Callable[[str], None]], pay
         extra={"log_context": log_context_fields},
     )
     if progress_cb is not None:
-        progress_cb(f"Compiler diagnostics: {json.dumps(payload, default=str, sort_keys=True)}")
+        progress_cb(
+            f"Compiler diagnostics: {json.dumps(payload, default=str, sort_keys=True)}"
+        )
 
 
 class VisualizationExecutionError(RuntimeError):
@@ -568,9 +1009,13 @@ class VisualizationExecutionError(RuntimeError):
         self.clarification_options = list(clarification_options or [])
 
 
-def _to_execution_error(failure_reasons: List[str], trace_id: Optional[str] = None) -> VisualizationExecutionError:
+def _to_execution_error(
+    failure_reasons: List[str], trace_id: Optional[str] = None
+) -> VisualizationExecutionError:
     reason_set = set(failure_reasons)
-    service_unavailable_count = sum(1 for reason in failure_reasons if reason == "service_unavailable")
+    service_unavailable_count = sum(
+        1 for reason in failure_reasons if reason == "service_unavailable"
+    )
     if "no_data" in reason_set:
         return VisualizationExecutionError(
             user_message="The analytics service returned no data for this visualization request. Try a wider date range or different filters.",
@@ -588,7 +1033,9 @@ def _to_execution_error(failure_reasons: List[str], trace_id: Optional[str] = No
     if "service_unavailable" in reason_set:
         if service_unavailable_count >= 2:
             return VisualizationExecutionError(
-                user_message=("The analytics platform appears to be experiencing an outage right now (upstream service unavailable). Please try again in a moment."),
+                user_message=(
+                    "The analytics platform appears to be experiencing an outage right now (upstream service unavailable). Please try again in a moment."
+                ),
                 reason="service_unavailable",
                 code="EXEC_SERVICE_UNAVAILABLE",
                 trace_id=trace_id,
@@ -704,10 +1151,14 @@ def _derive_distribution_defaults(metric_code: str) -> tuple[int, int, int]:
     return bins, rmin, rmax
 
 
-def _axis_from_meta(metric_code: str, x_min: int, x_max: int) -> tuple[ChartAxis, ChartAxis]:
+def _axis_from_meta(
+    metric_code: str, x_min: int, x_max: int
+) -> tuple[ChartAxis, ChartAxis]:
     metric_key = (metric_code or "").upper()
     meta = _get_metric_meta(metric_key)
-    display = _AXIS_LABEL_OVERRIDES.get(metric_key) or _normalize_axis_display_label(get_metric_display_name(metric_key))
+    display = _AXIS_LABEL_OVERRIDES.get(metric_key) or _normalize_axis_display_label(
+        get_metric_display_name(metric_key)
+    )
     unit_any: Any = meta.get("unit")
     if unit_any is None:
         unit_any = cast(Dict[str, Any], meta.get("numeric") or {}).get("unit")
@@ -849,7 +1300,9 @@ class RequestExecutionResult:
     series: List[ChartSeries]
 
 
-def _emit_progress(context: ExecutionContext, completed: int, total: int, prefix: str = "Fetching data") -> None:
+def _emit_progress(
+    context: ExecutionContext, completed: int, total: int, prefix: str = "Fetching data"
+) -> None:
     if context.progress_cb is None:
         return
     if total > 0:
@@ -927,7 +1380,9 @@ async def _execute_specs_concurrent(
         result = await task
         results.append(result)
         completed += 1
-        _emit_progress(context, completed=completed, total=total_requests, prefix=progress_prefix)
+        _emit_progress(
+            context, completed=completed, total=total_requests, prefix=progress_prefix
+        )
 
     return results
 
@@ -955,7 +1410,9 @@ async def _execute_specs_sequential(
         )
         results.append(result)
         completed += 1
-        _emit_progress(context, completed=completed, total=total_requests, prefix=progress_prefix)
+        _emit_progress(
+            context, completed=completed, total=total_requests, prefix=progress_prefix
+        )
 
     return results
 
@@ -985,7 +1442,9 @@ async def execute_plan_async(
     )
 
     try:
-        plan = resolve_plan_metric_origins(plan=plan, user_sub=user_sub, trace_id=trace_id_resolved)
+        plan = resolve_plan_metric_origins(
+            plan=plan, user_sub=user_sub, trace_id=trace_id_resolved
+        )
     except OriginScopeResolutionError as exc:
         raise VisualizationExecutionError(
             user_message=str(exc),
@@ -1004,7 +1463,11 @@ async def execute_plan_async(
     actual_queries = 0
     summary_batches: List[ExecutionBatchSummary] = []
 
-    resolved_concurrency = _EXECUTOR_DEFAULT_MAX_CONCURRENCY if max_concurrency is None else max(1, int(max_concurrency))
+    resolved_concurrency = (
+        _EXECUTOR_DEFAULT_MAX_CONCURRENCY
+        if max_concurrency is None
+        else max(1, int(max_concurrency))
+    )
     sem = asyncio.Semaphore(resolved_concurrency)
     execution_context = ExecutionContext(
         user_sub=user_sub,
@@ -1015,10 +1478,12 @@ async def execute_plan_async(
     )
 
     for planChart in plan_charts:
-        metric_requests, derived_axes, metric_data_origins, metric_scope_labels = build_metric_requests(
-            plan_chart=planChart,
-            derive_defaults_fn=_derive_distribution_defaults,
-            axis_from_meta_fn=_axis_from_meta,
+        metric_requests, derived_axes, metric_data_origins, metric_scope_labels = (
+            build_metric_requests(
+                plan_chart=planChart,
+                derive_defaults_fn=_derive_distribution_defaults,
+                axis_from_meta_fn=_axis_from_meta,
+            )
         )
 
         compiled_grouping = compile_chart_grouping(planChart)
@@ -1059,7 +1524,9 @@ async def execute_plan_async(
                     chart_type=planChart.chart_type,
                     server_groupby=gb_field,
                     filter_dimensions=[d.kind.__name__ for d in filter_dims],
-                    batched_time_period_count=len(batched_time_periods) if batched_time_enabled else 0,
+                    batched_time_period_count=len(batched_time_periods)
+                    if batched_time_enabled
+                    else 0,
                     query_count=total_requests,
                 )
             )
@@ -1135,14 +1602,20 @@ async def execute_plan_async(
                     total_requests=retry_count,
                     progress_prefix="Retrying with per-period requests",
                 )
-                all_series = [item for result in request_results for item in result.series]
+                all_series = [
+                    item for result in request_results for item in result.series
+                ]
 
             sampled_period_override = _sampled_period_from_specs(primary_specs)
             if sampled_period_override is None and fallback_specs:
                 sampled_period_override = _sampled_period_from_specs(fallback_specs)
 
             # Surface partial-result scenarios (some scopes returned no rows) without failing whole chart.
-            empty_scope_labels = [_request_scope_label(result.spec) for result in request_results if not result.series]
+            empty_scope_labels = [
+                _request_scope_label(result.spec)
+                for result in request_results
+                if not result.series
+            ]
             for scope_label in sorted(set(empty_scope_labels)):
                 warning_msg = f"No data was returned for {scope_label}. The chart includes the data that is available."
                 if warning_msg not in response.warnings:
@@ -1198,7 +1671,9 @@ async def execute_plan_async(
                     },
                 )
                 if request_failures:
-                    raise _to_execution_error(request_failures, trace_id=trace_id_resolved)
+                    raise _to_execution_error(
+                        request_failures, trace_id=trace_id_resolved
+                    )
                 raise _to_execution_error(["no_data"], trace_id=trace_id_resolved)
             vis_chart = build_chart_dto(
                 plan_chart=planChart,
@@ -1210,7 +1685,16 @@ async def execute_plan_async(
             response.charts.append(vis_chart)
 
     if plan.statistical_tests:
-        response.stats.extend(_execute_statistical_tests(plan=plan, user_sub=user_sub, trace_id=trace_id_resolved))
+        # Statistical tests issue backend requests outside chart batching; include
+        # them in the summary count so stats-only plans are not reported as zero.
+        actual_queries += len(plan.statistical_tests)
+        response.stats.extend(
+            _dedupe_statistical_results(
+                _execute_statistical_tests(
+                    plan=plan, user_sub=user_sub, trace_id=trace_id_resolved
+                )
+            )
+        )
 
     if summary_cb is not None:
         payload = make_execution_summary(

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -11,7 +11,7 @@
       "internal_error_routing": "Error routing visualization request: {error}",
       "internal_error_generating": "Error generating visualization: {error}",
       "internal_error_guided": "Error generating guided visualization: {error}",
-      "next_metric_payload": "Update visualization with to use {metric}",
+      "next_metric_payload": "Update visualization to use {metric}",
       "next_metric_button": "Show {metric}",
       "next_metric_suggestion": "Would you like to see the same visualization for {metric}?"
     },

--- a/src/planners/langchain/examples.py
+++ b/src/planners/langchain/examples.py
@@ -65,7 +65,10 @@ def example_dtn_by_first_contact_place() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line graph of DTN grouped by first contact place\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line graph of DTN grouped by first contact place\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -86,7 +89,10 @@ def example_dtn_line_basic() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line graph of DTN\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line graph of DTN\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -114,7 +120,10 @@ def example_dtn_histogram_custom_buckets() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a histogram of DTN with 12 bins between 0 and 180\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a histogram of DTN with 12 bins between 0 and 180\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -132,7 +141,10 @@ def example_dtn_males_only_filter() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line graph of DTN for males only\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line graph of DTN for males only\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -150,7 +162,10 @@ def example_dtn_females_only_filter() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line graph of DTN for females only\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line graph of DTN for females only\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -193,14 +208,19 @@ def example_one_graph_cross_split() -> Tuple[str, str]:
                 chart_type="LINE",
                 group_by=[
                     GroupBySex(categories=["MALE", "FEMALE"]),
-                    GroupByStrokeType(categories=["ISCHEMIC", "INTRACEREBRAL_HEMORRHAGE"]),
+                    GroupByStrokeType(
+                        categories=["ISCHEMIC", "INTRACEREBRAL_HEMORRHAGE"]
+                    ),
                 ],
                 metrics=[MetricSpec(metric="DTN")],
             )
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow DTN in one graph split by sex and stroke type\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow DTN in one graph split by sex and stroke type\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -221,13 +241,20 @@ def example_two_separate_charts() -> Tuple[str, str]:
             ),
             ChartSpec(
                 chart_type="BAR",
-                group_by=[GroupByStrokeType(categories=["ISCHEMIC", "INTRACEREBRAL_HEMORRHAGE"])],
+                group_by=[
+                    GroupByStrokeType(
+                        categories=["ISCHEMIC", "INTRACEREBRAL_HEMORRHAGE"]
+                    )
+                ],
                 metrics=[MetricSpec(metric="DTN")],
             ),
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nCreate two charts: DTN by sex and DTN by stroke type\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nCreate two charts: DTN by sex and DTN by stroke type\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -244,7 +271,9 @@ def example_dtn_last_6_months_by_sex() -> Tuple[str, str]:
             ChartSpec(
                 chart_type="LINE",
                 group_by=[
-                    GroupByTime(grain="MONTH", window=TimeWindow(last_n=6, unit="MONTH")),
+                    GroupByTime(
+                        grain="MONTH", window=TimeWindow(last_n=6, unit="MONTH")
+                    ),
                     GroupBySex(categories=["MALE", "FEMALE"]),
                 ],
                 metrics=[MetricSpec(metric="DTN")],
@@ -252,7 +281,10 @@ def example_dtn_last_6_months_by_sex() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me DTN by sex over the last 6 months, monthly\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me DTN by sex over the last 6 months, monthly\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -285,6 +317,69 @@ def example_statistical_test_dtn_by_sex() -> Tuple[str, str]:
     return user, assistant
 
 
+def example_statistical_test_dtn_by_quarter() -> Tuple[str, str]:
+    detected_entities = {
+        "metric": ["DTN"],
+        "quarter": ["Q4_2025", "Q1_2026"],
+        "scope": ["mine"],
+        "statistical_test_type": ["MANN_WHITNEY_U_TEST"],
+    }
+    plan = AnalysisPlan(
+        charts=None,
+        statistical_tests=[
+            StatisticalTestSpec(
+                test_type="MANN_WHITNEY_U_TEST",
+                metrics=[
+                    MetricSpec(
+                        metric="DTN",
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
+                    ),
+                    MetricSpec(
+                        metric="DTN",
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
+                    ),
+                ],
+                filters=AndFilter(
+                    and_=[
+                        DateFilter(operator="GE", value="2025-10-01"),
+                        DateFilter(operator="LE", value="2025-12-31"),
+                    ]
+                ),
+            ),
+            StatisticalTestSpec(
+                test_type="MANN_WHITNEY_U_TEST",
+                metrics=[
+                    MetricSpec(
+                        metric="DTN",
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
+                    ),
+                    MetricSpec(
+                        metric="DTN",
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
+                    ),
+                ],
+                filters=AndFilter(
+                    and_=[
+                        DateFilter(operator="GE", value="2026-01-01"),
+                        DateFilter(operator="LE", value="2026-03-31"),
+                    ]
+                ),
+            ),
+        ],
+    )
+    user = f"USER_UTTERANCE:\nRun a Mann-Whitney U test comparing DTN between Q4 2025 and Q1 2026 for my hospital\n\nENTITIES_DETECTED(JSON):\n{json.dumps(detected_entities)}"
+    assistant = plan.model_dump_json(indent=2)
+    return user, assistant
+
+
 def example_dtn_my_hospital_vs_country_average() -> Tuple[str, str]:
     detected_entities = {
         "metric": ["DTN"],
@@ -300,7 +395,9 @@ def example_dtn_my_hospital_vs_country_average() -> Tuple[str, str]:
                 metrics=[
                     MetricSpec(
                         metric="DTN",
-                        originScope=OriginScopeSpec(scopeType="mine", label="My hospital"),
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
                     ),
                     MetricSpec(
                         metric="DTN",
@@ -315,7 +412,10 @@ def example_dtn_my_hospital_vs_country_average() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nCompare DTN for my hospital against the Italy national average\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nCompare DTN for my hospital against the Italy national average\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -335,7 +435,9 @@ def example_dtn_my_hospital_vs_provider_group_name() -> Tuple[str, str]:
                 metrics=[
                     MetricSpec(
                         metric="DTN",
-                        originScope=OriginScopeSpec(scopeType="mine", label="My hospital"),
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
                     ),
                     MetricSpec(
                         metric="DTN",
@@ -350,7 +452,10 @@ def example_dtn_my_hospital_vs_provider_group_name() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow DTN for my hospital versus provider group Nordic Stroke Network\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow DTN for my hospital versus provider group Nordic Stroke Network\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -370,17 +475,24 @@ def example_mw_my_hospital_vs_national() -> Tuple[str, str]:
                 metrics=[
                     MetricSpec(
                         metric="DTN",
-                        originScope=OriginScopeSpec(scopeType="mine", label="My hospital"),
+                        originScope=OriginScopeSpec(
+                            scopeType="mine", label="My hospital"
+                        ),
                     ),
                     MetricSpec(
                         metric="DTN",
-                        originScope=OriginScopeSpec(scopeType="country_average", label="National mean"),
+                        originScope=OriginScopeSpec(
+                            scopeType="country_average", label="National mean"
+                        ),
                     ),
                 ],
             )
         ],
     )
-    user = "USER_UTTERANCE:\nCompare DTN between my hospital and the national mean\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nCompare DTN between my hospital and the national mean\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -398,7 +510,10 @@ def example_dtn_year_filter() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a bar chart of DTN for patients in 2026\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a bar chart of DTN for patients in 2026\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -419,7 +534,10 @@ def example_dtn_quarterly() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line chart of DTN per quarter\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line chart of DTN per quarter\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -440,7 +558,10 @@ def example_dtn_monthly() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line chart of DTN per month\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line chart of DTN per month\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -462,7 +583,10 @@ def example_dtn_ischemic_only_filter() -> Tuple[str, str]:
         ],
         statistical_tests=None,
     )
-    user = "USER_UTTERANCE:\nShow me a line graph of DTN for ischemic strokes only\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nShow me a line graph of DTN for ischemic strokes only\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -530,7 +654,10 @@ def example_mw_hospital_vs_hospital() -> Tuple[str, str]:
             )
         ],
     )
-    user = "USER_UTTERANCE:\nIs there a significant difference in DTN between City Stroke Center and University Hospital?\n\nENTITIES_DETECTED(JSON):\n" + json.dumps(detected_entities)
+    user = (
+        "USER_UTTERANCE:\nIs there a significant difference in DTN between City Stroke Center and University Hospital?\n\nENTITIES_DETECTED(JSON):\n"
+        + json.dumps(detected_entities)
+    )
     assistant = plan.model_dump_json(indent=2)
     return user, assistant
 
@@ -554,6 +681,7 @@ def get_few_shot_examples() -> List[Dict[str, str]]:
         example_dtn_by_sex(),
         example_dtn_by_sex_and_stroke(),
         example_statistical_test_dtn_by_sex(),
+        example_statistical_test_dtn_by_quarter(),
         example_dtn_year_filter(),
         example_dtn_quarterly(),
         example_dtn_monthly(),

--- a/src/planners/langchain/request_orchestrator.py
+++ b/src/planners/langchain/request_orchestrator.py
@@ -71,6 +71,23 @@ _TEMPORAL_MISSING_FIELDS = {
     "range",
 }
 
+_STAT_TEST_ENTITY_KEYS = {
+    "statistical_test_type",
+    "statistical_tests",
+    "test_type",
+    "test_types",
+}
+
+_STAT_TEST_KEYWORDS = (
+    "statistical test",
+    "mann-whitney",
+    "mann whitney",
+    "compare",
+    "significant",
+    "significance",
+    "difference between",
+)
+
 _DECISION_PROMPT = ChatPromptTemplate.from_messages(  # type: ignore[attr-defined]
     [
         (
@@ -88,9 +105,10 @@ Return strict JSON only:
 }}
 
 Rules:
-- The ONLY required fields are metric and chart_type. Everything else is optional.
-- If both metric and chart_type are known, return decision="proceed" and message=null.
-- If only one is missing, return decision="clarify", put the missing field in missing_fields, and write one concise question in message (under 25 words).
+- For chart requests, required fields are metric and chart_type.
+- For statistical-test-only requests, required fields are metric and statistical_test_type; chart_type is optional and should not trigger clarification.
+- If required fields for the detected intent are present, return decision="proceed" and message=null.
+- If one required field is missing, return decision="clarify", put the missing field in missing_fields, and write one concise question in message (under 25 words).
 - If out of scope, return decision="reject" with a short message.
 - Never ask the user to clarify or provide time_scope, time_range, grouping_dimension, sex, or stroke_type — these are optional and should be accepted if present, not rejected.
 - Prefer resolving metrics from VALID_METRIC_CANDIDATES_JSON before asking.
@@ -241,6 +259,27 @@ def _coerce_options(raw: Any) -> List[str]:
     return out
 
 
+def _is_missing_chart_type_only(missing_fields: List[str]) -> bool:
+    normalized = [field.strip().lower() for field in missing_fields if field and field.strip()]
+    return bool(normalized) and all(field == "chart_type" for field in normalized)
+
+
+def _has_statistical_test_signal(question: str, entities: Dict[str, Any]) -> bool:
+    for key in _STAT_TEST_ENTITY_KEYS:
+        value = entities.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+        if isinstance(value, list):
+            value_list = cast(List[Any], value)
+            if any(isinstance(item, str) and item.strip() for item in value_list):
+                return True
+
+    question_norm = (question or "").strip().lower()
+    if not question_norm:
+        return False
+    return any(keyword in question_norm for keyword in _STAT_TEST_KEYWORDS)
+
+
 def _decision_stage(
     question: str,
     entities: Dict[str, Any],
@@ -274,7 +313,7 @@ def _decision_stage(
     llm_message_raw = parsed.get("message")
     llm_message = llm_message_raw.strip() if isinstance(llm_message_raw, str) and llm_message_raw.strip() else None
 
-    return VisualizationRequestOutcome(
+    outcome = VisualizationRequestOutcome(
         decision=cast(OutcomeDecision, decision_raw),
         reason=reason,
         message=llm_message,
@@ -282,6 +321,23 @@ def _decision_stage(
         clarification_options=clarification_options,
         missing_fields=missing_fields,
     )
+
+    # Deterministic safeguard: do not block statistical-test requests on chart_type.
+    if (
+        outcome.decision == "clarify"
+        and _is_missing_chart_type_only(outcome.missing_fields)
+        and _has_statistical_test_signal(question, entities)
+    ):
+        return VisualizationRequestOutcome(
+            decision="proceed",
+            reason="statistical_test_without_chart_type",
+            message=None,
+            clarification_type=None,
+            clarification_options=[],
+            missing_fields=[],
+        )
+
+    return outcome
 
 
 def orchestrate_visualization_request(

--- a/tests/test_long_action_callback_payload.py
+++ b/tests/test_long_action_callback_payload.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    package = types.ModuleType(name)
+    package.__path__ = [str(path)]
+    sys.modules[name] = package
+
+
+def _load_module(module_name: str, relative_path: str):
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_ensure_package("src", _ROOT / "src")
+_ensure_package("src.actions", _ROOT / "src/actions")
+_ensure_package("src.actions.long_action", _ROOT / "src/actions/long_action")
+
+rasa_sdk_module = types.ModuleType("rasa_sdk")
+
+
+class _StubAction:
+    pass
+
+
+rasa_sdk_module.Action = _StubAction
+sys.modules.setdefault("rasa_sdk", rasa_sdk_module)
+
+_load_module("src.actions.long_action.long_action_registry", "src/actions/long_action/long_action_registry.py")
+long_action_context_module = _load_module(
+    "src.actions.long_action.long_action_context",
+    "src/actions/long_action/long_action_context.py",
+)
+long_action_module = _load_module(
+    "src.actions.long_action.long_action",
+    "src/actions/long_action/long_action.py",
+)
+
+LongAction = long_action_module.LongAction
+LongActionContext = long_action_context_module.LongActionContext
+
+
+class _FakeLongAction(LongAction):
+    def name(self) -> str:
+        return "fake_long_action"
+
+    async def work(self, ctx: LongActionContext) -> Any:
+        return None
+
+
+class LongActionCallbackPayloadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.action = _FakeLongAction()
+
+    def test_build_callback_payload_wraps_user_visible_message_as_tracker_event(self) -> None:
+        ctx = LongActionContext(sender_id="u1:thread:7", tracker_snapshot={})
+
+        payload = self.action._build_callback_payload(
+            ctx,
+            {
+                "text": "Hello there",
+                "custom": {"progress": "working"},
+                "buttons": [{"title": "Retry", "payload": "/retry"}],
+            },
+            trace_id="trace-123",
+        )
+
+        self.assertEqual(payload["senderId"], "u1:thread:7")
+        self.assertEqual(payload["controls"], [])
+        self.assertEqual(len(payload["events"]), 1)
+
+        event = payload["events"][0]
+        self.assertEqual(event["event"], "bot")
+        self.assertEqual(event["text"], "Hello there")
+        self.assertEqual(event["metadata"]["source"], "long-task-callback")
+        self.assertEqual(event["metadata"]["trace_id"], "trace-123")
+        self.assertEqual(event["data"]["custom"], {"progress": "working"})
+        self.assertEqual(event["data"]["buttons"], [{"title": "Retry", "payload": "/retry"}])
+
+    def test_build_callback_payload_emits_lock_as_control_signal(self) -> None:
+        ctx = LongActionContext(sender_id="u1:thread:7", tracker_snapshot={})
+        ctx._job_id = "job-abc"
+
+        payload = self.action._build_callback_payload(
+            ctx,
+            {"type": "lock"},
+            trace_id="trace-123",
+        )
+
+        self.assertEqual(payload["senderId"], "u1:thread:7")
+        self.assertEqual(payload["events"], [])
+        self.assertEqual(
+            payload["controls"],
+            [{
+                "type": "lock",
+                "jobId": "job-abc",
+                "scope": "long_action",
+                "source": "long-task-callback",
+                "traceId": "trace-123",
+            }],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on enhanced debugging, improved callback payload structure for long-running actions, and expanded test coverage with new and refactored examples. The most important changes are grouped below:

**Debugging and Developer Experience:**
* Added a new environment flag (`_EMIT_QUERY_DEBUG`) and conditional debug output for GraphQL queries in both `guided_visualization_action.py` and `visualization_action.py`. This allows developers to easily enable or disable verbose query logging for troubleshooting. [[1]](diffhunk://#diff-8c046fd437bef4ddff662ac352eb2d6b9a2a9f03cb81c397f8b2b6514f7a9eedR38) [[2]](diffhunk://#diff-8c046fd437bef4ddff662ac352eb2d6b9a2a9f03cb81c397f8b2b6514f7a9eedR142) [[3]](diffhunk://#diff-5470777f6453268b5f2dab830fa71fa8bf4f1d59769eb216da92d959f47c73adR40) [[4]](diffhunk://#diff-5470777f6453268b5f2dab830fa71fa8bf4f1d59769eb216da92d959f47c73adR939)

**Long Action Callback Refactor:**
* Refactored the callback payload structure in `long_action.py` to separate user-visible messages (as tracker events) from control signals (lock/release), and introduced helper methods for payload construction and control message detection. This makes the callback envelope more explicit and easier to handle on the frontend. [[1]](diffhunk://#diff-9077d841f902fc2b03ca0d1bbb533e7c27b13b82782d469c4779939bdb396defR333-R380) [[2]](diffhunk://#diff-9077d841f902fc2b03ca0d1bbb533e7c27b13b82782d469c4779939bdb396defL393-R442) [[3]](diffhunk://#diff-9077d841f902fc2b03ca0d1bbb533e7c27b13b82782d469c4779939bdb396defR473) [[4]](diffhunk://#diff-9077d841f902fc2b03ca0d1bbb533e7c27b13b82782d469c4779939bdb396defL459-R516) [[5]](diffhunk://#diff-9077d841f902fc2b03ca0d1bbb533e7c27b13b82782d469c4779939bdb396defL598-R649)

**Examples and Testing Enhancements:**
* Refactored several example functions in `examples.py` for improved readability and maintainability (multi-line formatting, clearer construction of user/assistant pairs), and added a new example for running a Mann-Whitney U test comparing DTN between quarters. [[1]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L68-R71) [[2]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L89-R95) [[3]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L117-R126) [[4]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L135-R147) [[5]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L153-R168) [[6]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L196-R223) [[7]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L224-R257) [[8]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L247-R287) [[9]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47R320-R382) [[10]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L303-R400) [[11]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L318-R418) [[12]](diffhunk://#diff-311bc3bac26e1f61a1905be47856743db6b879a381a1c27a858c4959acce0a47L338-R440)

**Configuration:**
* Updated `.github/dependabot.yml` to set `target-branch: dev` for all package ecosystems, ensuring dependency updates are proposed against the correct branch.

**Localization:**
* Fixed a typo in a user-facing string in `common.json` for clarity.