### PR TITLE
feat(ci): add auto/manual immutable tags while keeping channel tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,32 +53,40 @@ jobs:
         run: |
           SHORT_SHA="${GITHUB_SHA::7}"
           BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          BUILD_SOURCE="auto"
+          RAW_REF="${TARGET_REF:-${GITHUB_REF_NAME}}"
+          SAFE_REF="$(echo "$RAW_REF" | tr '[:upper:]' '[:lower:]' | tr '/ ' '-' | tr -cd 'a-z0-9._-')"
 
           echo "BUILD_DATE=$BUILD_DATE" >> "$GITHUB_ENV"
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            RAW_REF="${TARGET_REF:-${GITHUB_REF_NAME}}"
-            SAFE_REF="$(echo "$RAW_REF" | tr '[:upper:]' '[:lower:]' | tr '/ ' '-' | tr -cd 'a-z0-9._-')"
-            if [ -z "$SAFE_REF" ]; then
-              SAFE_REF="manual"
-            fi
-            echo "IMAGE_TAG=${SAFE_REF}-manual" >> "$GITHUB_ENV"
-            echo "IMAGE_SHA_TAG=${SAFE_REF}-${SHORT_SHA}" >> "$GITHUB_ENV"
-            exit 0
+            BUILD_SOURCE="manual"
           fi
 
-          case "${GITHUB_REF_NAME}" in
+          if [ -z "$SAFE_REF" ]; then
+            SAFE_REF="manual"
+          fi
+
+          case "$SAFE_REF" in
             master)
               echo "IMAGE_TAG=latest" >> "$GITHUB_ENV"
               echo "IMAGE_SHA_TAG=master-$SHORT_SHA" >> "$GITHUB_ENV"
+              echo "IMAGE_SOURCE_TAG=master-$BUILD_SOURCE-$SHORT_SHA" >> "$GITHUB_ENV"
               ;;
             dev)
               echo "IMAGE_TAG=dev" >> "$GITHUB_ENV"
               echo "IMAGE_SHA_TAG=dev-$SHORT_SHA" >> "$GITHUB_ENV"
+              echo "IMAGE_SOURCE_TAG=dev-$BUILD_SOURCE-$SHORT_SHA" >> "$GITHUB_ENV"
               ;;
             *)
-              echo "Unsupported branch for docker publish: ${GITHUB_REF_NAME}" >&2
-              exit 1
+              if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+                echo "IMAGE_TAG=$SAFE_REF" >> "$GITHUB_ENV"
+                echo "IMAGE_SHA_TAG=$SAFE_REF-$SHORT_SHA" >> "$GITHUB_ENV"
+                echo "IMAGE_SOURCE_TAG=$SAFE_REF-$BUILD_SOURCE-$SHORT_SHA" >> "$GITHUB_ENV"
+              else
+                echo "Unsupported branch for docker publish: ${GITHUB_REF_NAME}" >&2
+                exit 1
+              fi
               ;;
           esac
 
@@ -114,4 +122,5 @@ jobs:
             --build-arg ACTION_SSOT_VERSION=$SSOT_SHA \
             -t ghcr.io/$REPO_NAME_LC:$IMAGE_TAG \
             -t ghcr.io/$REPO_NAME_LC:$IMAGE_SHA_TAG \
+            -t ghcr.io/$REPO_NAME_LC:$IMAGE_SOURCE_TAG \
             .


### PR DESCRIPTION
This pull request makes improvements to the Docker image tagging process in the GitHub Actions workflow. It introduces a new `IMAGE_SOURCE_TAG` environment variable to provide more detailed tagging, refines how tags are generated for different build sources (manual vs. automatic), and ensures consistent lowercasing and sanitization of branch names for tags.

**Enhancements to Docker image tagging:**

* Added a new `IMAGE_SOURCE_TAG` variable that combines branch/ref, build source (manual or auto), and commit SHA for more granular image identification. This tag is now applied to all built images. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R56-R89) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R125)
* Improved branch/ref name handling by consistently lowercasing and sanitizing the value used in tags, reducing the risk of invalid tag names.

**Workflow logic improvements:**

* Refined logic to distinguish between manual (`workflow_dispatch`) and automatic builds, setting the `BUILD_SOURCE` variable accordingly and applying appropriate tags.
* Ensured that only supported branches or refs are allowed for Docker publishing, with clear error handling for unsupported cases.