### PR TITLE
 Fix action_explain_metric: extract_metric() checked the wrong entity name

### DIFF
--- a/src/actions/actions/metric_action.py
+++ b/src/actions/actions/metric_action.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from rasa_sdk import Action  # type: ignore
 
 from src.actions.error_messages import friendly_metric_error
-from src.actions.helpers.metric import extract_kpi, pick_description, resolve_language, suggest_metrics
+from src.actions.helpers.metric import extract_metric, pick_description, resolve_language, suggest_metrics
 from src.actions.i18n import translate
 from src.shared import ssot_loader
 from src.util import env as env_util
@@ -76,9 +76,9 @@ def _tracker_trace_id(tracker: TrackerLike) -> Optional[str]:
 class ActionExplainMetric(Action):  # pyright: ignore
     """Explain a metric/KPI based on MetricType.yml and language.
 
-    The metric is resolved from the latest user message `kpi` entity (or the
-    `kpi` slot as a fallback), normalized using the same rules as the SSOT
-    lookup. The response uses the localized description from the SSOT
+    The metric is resolved from the latest user message `metric` entity (or
+    the `metric` slot as a fallback), normalized using the same rules as the
+    SSOT lookup. The response uses the localized description from the SSOT
     `descriptions` block, falling back to English or the first available
     language.
     """
@@ -97,12 +97,12 @@ class ActionExplainMetric(Action):  # pyright: ignore
             try:
                 language = resolve_language(tracker)
 
-                raw_kpi = extract_kpi(tracker)
-                if not raw_kpi:
+                raw_metric = extract_metric(tracker)
+                if not raw_metric:
                     dispatcher.utter_message(text=translate("action.metric.missing_metric", language=language))
                     return []
 
-                norm_key = ssot_loader.normalize_metric_text_key(raw_kpi)
+                norm_key = ssot_loader.normalize_metric_text_key(raw_metric)
                 if not norm_key:
                     dispatcher.utter_message(text=translate("action.metric.metric_not_understood", language=language))
                     return []

--- a/src/actions/helpers/__init__.py
+++ b/src/actions/helpers/__init__.py
@@ -1,5 +1,5 @@
 from .hospital import extract_hospital_filters
-from .metric import extract_kpi, pick_description, resolve_language, suggest_metrics
+from .metric import extract_metric, pick_description, resolve_language, suggest_metrics
 from .visualization import extract_entities_from_latest_message, format_execution_summary, resolve_override_language
 
 __all__ = [
@@ -8,7 +8,7 @@ __all__ = [
     "format_execution_summary",
     "extract_hospital_filters",
     "resolve_language",
-    "extract_kpi",
+    "extract_metric",
     "pick_description",
     "suggest_metrics",
 ]

--- a/src/actions/helpers/metric.py
+++ b/src/actions/helpers/metric.py
@@ -29,7 +29,7 @@ def resolve_language(tracker: Any) -> str:
     return primary or "en"
 
 
-def extract_kpi(tracker: Any) -> Optional[str]:
+def extract_metric(tracker: Any) -> Optional[str]:
     tracker_any: Any = tracker
     latest: Dict[str, Any] = tracker_any.latest_message or {}
     entities_any: Any = latest.get("entities")
@@ -39,12 +39,12 @@ def extract_kpi(tracker: Any) -> Optional[str]:
             if not isinstance(ent_any, dict):
                 continue
             ent = cast(Dict[str, Any], ent_any)
-            if ent.get("entity") == "kpi":
+            if ent.get("entity") == "metric":
                 val = ent.get("value")
                 if isinstance(val, str) and val.strip():
                     return val.strip()
 
-    slot_val_any: Any = tracker_any.get_slot("kpi")
+    slot_val_any: Any = tracker_any.get_slot("metric")
     if isinstance(slot_val_any, str) and slot_val_any.strip():
         return slot_val_any.strip()
 

--- a/src/shared/ssot_loader.py
+++ b/src/shared/ssot_loader.py
@@ -184,7 +184,7 @@ def get_metric_metadata() -> Dict[str, Dict[str, Any]]:
             if val is not None:
                 meta[key] = val
 
-        descriptions = _coerce_description_map(item.get("description"))
+        descriptions = _coerce_description_map(item.get("descriptions"))
         if descriptions:
             meta["descriptions"] = descriptions
 
@@ -414,7 +414,7 @@ def get_metric_text_lookup() -> Dict[str, Dict[str, Any]]:
         code = canonical.strip().upper()
 
         synonyms = _flatten_synonyms(item.get("synonyms"))
-        descriptions = _coerce_description_map(item.get("description"))
+        descriptions = _coerce_description_map(item.get("descriptions"))
 
         data_type_any = _ci_get(item, "data_type")
         data_type: Optional[str]

--- a/tests/test_metric_action_entity_extraction.py
+++ b/tests/test_metric_action_entity_extraction.py
@@ -1,0 +1,38 @@
+import unittest
+from typing import Any, Dict, List, Optional
+
+from src.actions.helpers.metric import extract_metric
+
+
+class _FakeTracker:
+    def __init__(self, entities: Optional[List[Dict[str, Any]]] = None, slots: Optional[Dict[str, Any]] = None) -> None:
+        self.latest_message = {"entities": entities or []}
+        self._slots = slots or {}
+
+    def get_slot(self, name: str) -> Any:
+        return self._slots.get(name)
+
+
+class ExtractMetricTests(unittest.TestCase):
+    def test_reads_metric_entity_from_latest_message(self) -> None:
+        tracker = _FakeTracker(entities=[{"entity": "metric", "value": "DTN"}])
+        self.assertEqual(extract_metric(tracker), "DTN")
+
+    def test_ignores_legacy_kpi_entity_name(self) -> None:
+        # The "metric" entity is what SSOTCanonicalizer and every current NLU
+        # example actually produce; a stray "kpi"-tagged entity should not
+        # be picked up.
+        tracker = _FakeTracker(entities=[{"entity": "kpi", "value": "DTN"}])
+        self.assertIsNone(extract_metric(tracker))
+
+    def test_falls_back_to_metric_slot(self) -> None:
+        tracker = _FakeTracker(entities=[], slots={"metric": "DIDO"})
+        self.assertEqual(extract_metric(tracker), "DIDO")
+
+    def test_returns_none_when_nothing_available(self) -> None:
+        tracker = _FakeTracker()
+        self.assertIsNone(extract_metric(tracker))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ssot_loader.py
+++ b/tests/test_ssot_loader.py
@@ -16,7 +16,7 @@ class SsotLoaderTests(unittest.TestCase):
                     "en": ["clot removal", "mechanical thrombectomy"],
                     "el": ["αφαίρεση θρόμβου"],
                 },
-                "description": {
+                "descriptions": {
                     "en": "Description for THROMBECTOMY",
                     "el": "Περιγραφή για ΘΡΟΜΒΕΚΤΟΜΙΑ",
                 },
@@ -35,8 +35,20 @@ class SsotLoaderTests(unittest.TestCase):
             "Περιγραφή για ΘΡΟΜΒΕΚΤΟΜΙΑ",
         )
 
+    def test_metric_metadata_has_real_descriptions_from_disk(self) -> None:
+        # Regression guard: MetricType.yml uses "descriptions" (plural), unlike
+        # every other SSOT file which uses "description" (singular). A mock-only
+        # test can't catch a mismatch against the real key -- this reads the
+        # actual on-disk file to make sure descriptions are non-empty.
+        ssot_loader.get_metric_metadata.cache_clear()
+        metadata = ssot_loader.get_metric_metadata()
+        self.assertIn("DTN", metadata)
+        self.assertIn("descriptions", metadata["DTN"])
+        self.assertTrue(metadata["DTN"]["descriptions"].get("en"))
+
     def tearDown(self) -> None:
         ssot_loader.get_metric_text_lookup.cache_clear()
+        ssot_loader.get_metric_metadata.cache_clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
extract_kpi() looked for an entity/slot literally named kpi, which hasn't existed since a rename to metric — every real training example for ask_metric_definition tags (metric), and Rasa's SSOTCanonicalizer renamed any stray kpi before Action saw it anyway. Net effect: action_explain_metric couldn't resolve a metric from any real phrasing, always hit the fallback message. Renamed to extract_metric, fixed the check, added regression tests.