### PR TITLE
Resolve country codes via SSOT instead of a 5-country hardcoded dict

### DIFF
--- a/src/executors/analytics_center/client.py
+++ b/src/executors/analytics_center/client.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 
 import requests
 
+from src.shared import ssot_loader
 from src.util import env as env_util
 from src.util.logging_utils import log_context
 
@@ -701,28 +702,15 @@ class AnalyticsCenterClient:
         raw = (country_input or "").strip()
         if not raw:
             return None
-        if len(raw) == 2 and raw.isalpha():
-            return raw.upper()
 
-        aliases: Dict[str, str] = {
-            "spain": "ES",
-            "espana": "ES",
-            "españa": "ES",
-            "mexico": "MX",
-            "méxico": "MX",
-            "czech republic": "CZ",
-            "czechia": "CZ",
-            "united kingdom": "GB",
-            "uk": "GB",
-            "great britain": "GB",
-            "united states": "US",
-            "usa": "US",
-            "u.s.a": "US",
-        }
+        ssot_canonical = ssot_loader.resolve_country_code(raw)
+        if ssot_canonical:
+            return ssot_canonical
+
+        # SSOT/CountryType.yml doesn't recognize it -- fall back to an exact
+        # match against whatever this deployment's Analytics Center backend
+        # actually has data for.
         normalized = raw.lower()
-        if normalized in aliases:
-            return aliases[normalized]
-
         countries_page = self.list_countries(
             user_sub=user_sub,
             limit=300,

--- a/src/shared/ssot_loader.py
+++ b/src/shared/ssot_loader.py
@@ -743,6 +743,12 @@ def resolve_stroke_type(value: str) -> Optional[str]:
     return _resolve_canonical_value("StrokeType.yml", value)
 
 
+def resolve_country_code(value: str) -> Optional[str]:
+    """Resolve a country name or ISO 3166-1 alpha-2 code (canonical or synonym)
+    to its CountryType.yml canonical code."""
+    return _resolve_canonical_value("CountryType.yml", value)
+
+
 __all__ = [
     "BASE_SSOT",
     "create_enum",

--- a/tests/test_ssot_loader.py
+++ b/tests/test_ssot_loader.py
@@ -39,5 +39,41 @@ class SsotLoaderTests(unittest.TestCase):
         ssot_loader.get_metric_text_lookup.cache_clear()
 
 
+class ResolveCountryCodeTests(unittest.TestCase):
+    _ITEMS: List[Dict[str, Any]] = [
+        {
+            "canonical": "CZ",
+            "synonyms": {"en": ["Czechia", "Czech Republic"], "cs": ["Česko"]},
+        },
+        {
+            "canonical": "ES",
+            "synonyms": {"en": ["Spain", "Espana", "España"], "cs": ["Španělsko"]},
+        },
+    ]
+
+    def setUp(self) -> None:
+        ssot_loader._canonical_lookup.cache_clear()
+        self._patcher = mock.patch.object(ssot_loader, "_load_yaml", return_value=self._ITEMS)
+        self._patcher.start()
+
+    def tearDown(self) -> None:
+        self._patcher.stop()
+        ssot_loader._canonical_lookup.cache_clear()
+
+    def test_resolves_bare_iso_code(self) -> None:
+        self.assertEqual(ssot_loader.resolve_country_code("cz"), "CZ")
+
+    def test_resolves_english_synonym(self) -> None:
+        self.assertEqual(ssot_loader.resolve_country_code("Czech Republic"), "CZ")
+        self.assertEqual(ssot_loader.resolve_country_code("Czechia"), "CZ")
+
+    def test_resolves_diacritic_variant(self) -> None:
+        self.assertEqual(ssot_loader.resolve_country_code("España"), "ES")
+        self.assertEqual(ssot_loader.resolve_country_code("Espana"), "ES")
+
+    def test_unknown_country_returns_none(self) -> None:
+        self.assertIsNone(ssot_loader.resolve_country_code("Narnia"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Deleted the hardcoded alias dict in resolve_country_code(); added ssot_loader.resolve_country_code() mirroring resolve_sex/resolve_stroke_type. Live-API fallback kept (different purpose: "what's in this deployment's data" vs. "what's a valid country"). Depends on SSOT PR (CountryType.yml).