### PR TITLE
Remove hardcoded operator/axis-label duplicates from chart_builder + metric defaults

### DIFF
--- a/src/executors/mapping/chart_builder.py
+++ b/src/executors/mapping/chart_builder.py
@@ -26,6 +26,7 @@ from src.shared.ssot_loader import (
     get_canonical_display_name,
     get_metric_display_name,
     get_metric_metadata,
+    get_operator_symbol,
 )
 
 logger = logging.getLogger(__name__)
@@ -66,9 +67,9 @@ def _dimension_label(dimension: Dimension) -> Optional[str]:
         grain = getattr(dimension.spec, "grain", None)
         return str(grain or "time").lower()
     if isinstance(dimension.spec, GroupBySex):
-        return "Sex"
+        return get_canonical_display_name("SEX_TYPE")
     if isinstance(dimension.spec, GroupByStrokeType):
-        return "Stroke Type"
+        return get_canonical_display_name("STROKE_TYPE")
     if isinstance(dimension.spec, GroupByNIHSS):
         return get_canonical_display_name("ADMISSION_NIHSS")
     if isinstance(dimension.spec, GroupByAge):
@@ -93,16 +94,7 @@ def _metric_codes(plan_chart: S.ChartSpec) -> List[str]:
 
 
 def _format_operator(value: str) -> str:
-    token = (value or "").strip().upper()
-    mapping = {
-        "GE": ">=",
-        "GT": ">",
-        "LE": "<=",
-        "LT": "<",
-        "EQ": "=",
-        "NE": "!=",
-    }
-    return mapping.get(token, token)
+    return get_operator_symbol(value)
 
 
 def _format_filter_text(filter_node: Optional[Any], include_date: bool = True) -> str:
@@ -126,15 +118,15 @@ def _format_filter_text(filter_node: Optional[Any], include_date: bool = True) -
         if isinstance(node, S.DateFilter):
             if not include_date:
                 return ""
-            operator = _format_operator(str(getattr(node, "operator", "")))
+            operator = get_operator_symbol(str(getattr(node, "operator", "")))
             value = str(getattr(node, "value", ""))
             return f"discharge date {operator} {value}"
         if isinstance(node, S.AgeFilter):
-            operator = _format_operator(str(getattr(node, "operator", "")))
+            operator = get_operator_symbol(str(getattr(node, "operator", "")))
             value = getattr(node, "value", "")
             return f"age {operator} {value:g}" if isinstance(value, (int, float)) else f"age {operator} {value}"
         if isinstance(node, S.NIHSSFilter):
-            operator = _format_operator(str(getattr(node, "operator", "")))
+            operator = get_operator_symbol(str(getattr(node, "operator", "")))
             value = getattr(node, "value", "")
             return f"nihss {operator} {value:g}" if isinstance(value, (int, float)) else f"nihss {operator} {value}"
         if isinstance(node, S.SexFilter):
@@ -282,9 +274,9 @@ def _axis_label_for_dimension(dimension: Dimension) -> str:
         }
         return label_map.get(grain, _title_case_token(grain))
     if isinstance(dimension.spec, GroupBySex):
-        return "Sex"
+        return get_canonical_display_name("SEX_TYPE")
     if isinstance(dimension.spec, GroupByStrokeType):
-        return "Stroke Type"
+        return get_canonical_display_name("STROKE_TYPE")
     if isinstance(dimension.spec, GroupByNIHSS):
         return get_canonical_display_name("ADMISSION_NIHSS")
     if isinstance(dimension.spec, GroupByAge):

--- a/src/executors/planning/ssot_metric_defaults.py
+++ b/src/executors/planning/ssot_metric_defaults.py
@@ -18,18 +18,6 @@ logger = logging.getLogger(__name__)
 
 _METRIC_METADATA: Dict[str, Any] = get_metric_metadata()
 
-_AXIS_LABEL_OVERRIDES: Dict[str, str] = {
-    "DTN": "Door-to-Needle Time",
-    "ONSET_TO_DOOR": "Onset-to-Door Time",
-    "DOOR_TO_REPERFUSION": "Door-to-Reperfusion Time",
-}
-
-_AXIS_UNIT_OVERRIDES: Dict[str, str] = {
-    "DTN": "minutes",
-    "ONSET_TO_DOOR": "minutes",
-    "DOOR_TO_REPERFUSION": "minutes",
-}
-
 _AXIS_ACRONYMS = {"NIHSS", "DTN", "IVT", "EVT", "TIA", "LVO", "ICH", "SAH", "CT", "MRI"}
 
 
@@ -148,12 +136,10 @@ def get_histogram_axes(
     code = (metric_code or "").upper()
     meta = _mapping_to_dict(_METRIC_METADATA.get(code))
 
-    display = _AXIS_LABEL_OVERRIDES.get(code) or _normalize_axis_display_label(
-        get_metric_display_name(code)
-    )
+    display = _normalize_axis_display_label(get_metric_display_name(code))
 
     unit_any: Any = meta.get("unit") or _mapping_to_dict(meta.get("numeric")).get("unit")
-    unit: Optional[str] = cast(Optional[str], unit_any) or _AXIS_UNIT_OVERRIDES.get(code)
+    unit: Optional[str] = cast(Optional[str], unit_any)
 
     x_label = f"{display} ({unit})" if unit else display
     return ChartAxis(label=x_label, min_value=x_min, max_value=x_max), ChartAxis(label="Cases")

--- a/src/shared/ssot_loader.py
+++ b/src/shared/ssot_loader.py
@@ -627,6 +627,17 @@ def get_metric_display_name(metric_code: str) -> str:
     return code
 
 
+def get_operator_symbol(operator_code: str) -> str:
+    """Return SSOT-preferred display symbol for a comparison operator (first synonym), fallback to canonical code."""
+    code = (operator_code or "").strip().upper()
+    for item in _load_yaml("OperatorType.yml"):
+        if item.get("canonical") == code:
+            symbol = _first_synonym(item)
+            if symbol:
+                return symbol
+    return code
+
+
 def get_enum_option_label(metric_code: str, key: str) -> Optional[str]:
     """Return preferred label for an enum option of a given metric from SSOT.
 

--- a/tests/test_chart_builder.py
+++ b/tests/test_chart_builder.py
@@ -1,8 +1,16 @@
 import unittest
 
 from src.domain.dto.charts.types import ChartPoint, ChartSeries
-from src.domain.langchain.schema import ChartSpec, MetricSpec
-from src.executors.mapping.chart_builder import build_chart_dto
+from src.domain.langchain.schema import ChartSpec, GroupBySex, GroupByStrokeType, MetricSpec
+from src.executors.mapping.chart_builder import (
+    _axis_label_for_dimension,
+    _dimension_label,
+    _format_operator,
+    build_chart_dto,
+)
+from src.executors.planning.query_compiler import Dimension
+from src.executors.planning.ssot_metric_defaults import get_histogram_axes
+from src.shared.ssot_loader import get_canonical_display_name
 
 
 class ChartBuilderTests(unittest.TestCase):
@@ -41,6 +49,39 @@ class ChartBuilderTests(unittest.TestCase):
         self.assertEqual(x_axis.type.value, "linear")
         self.assertEqual(y_axis.label, "Cases")
         self.assertEqual(y_axis.type.value, "linear")
+
+
+class OperatorSymbolTests(unittest.TestCase):
+    def test_format_operator_matches_ssot(self) -> None:
+        expected = {"GE": ">=", "LE": "<=", "LT": "<", "GT": ">", "EQ": "=", "NE": "!="}
+        for code, symbol in expected.items():
+            self.assertEqual(_format_operator(code), symbol)
+
+
+class DimensionLabelSsotConsistencyTests(unittest.TestCase):
+    # Sex/StrokeType axis labels used to be hardcoded ("Sex", "Stroke Type");
+    # they now come from SSOT like every other dimension label in this module
+    # (NIHSS, Age, generic canonical fields already did). This just pins the
+    # label to whatever SSOT currently says, so a future SSOT wording change
+    # is a deliberate, visible test update rather than a silent surprise.
+    def test_axis_label_for_sex_dimension_comes_from_ssot(self) -> None:
+        dimension = Dimension(GroupBySex(categories=None))
+        expected = get_canonical_display_name("SEX_TYPE")
+        self.assertEqual(_axis_label_for_dimension(dimension), expected)
+        self.assertEqual(_dimension_label(dimension), expected)
+
+    def test_axis_label_for_stroke_type_dimension_comes_from_ssot(self) -> None:
+        dimension = Dimension(GroupByStrokeType(categories=None))
+        expected = get_canonical_display_name("STROKE_TYPE")
+        self.assertEqual(_axis_label_for_dimension(dimension), expected)
+        self.assertEqual(_dimension_label(dimension), expected)
+
+
+class HistogramAxesTests(unittest.TestCase):
+    def test_dtn_histogram_axis_no_longer_needs_a_hardcoded_override(self) -> None:
+        x_axis, y_axis = get_histogram_axes("DTN", x_min=0, x_max=520)
+        self.assertIn("minutes", x_axis.label)
+        self.assertEqual(y_axis.label, "Cases")
 
 
 if __name__ == "__main__":

--- a/tests/test_ssot_loader.py
+++ b/tests/test_ssot_loader.py
@@ -39,5 +39,18 @@ class SsotLoaderTests(unittest.TestCase):
         ssot_loader.get_metric_text_lookup.cache_clear()
 
 
+class GetOperatorSymbolTests(unittest.TestCase):
+    def test_returns_real_symbols_from_disk(self) -> None:
+        # Regression guard: OperatorType.yml's GE/LE/EQ entries must keep the
+        # symbol as their first synonym, since get_operator_symbol (like every
+        # other SSOT display accessor) just returns the first synonym.
+        expected = {"GE": ">=", "LE": "<=", "LT": "<", "GT": ">", "EQ": "=", "NE": "!="}
+        for code, symbol in expected.items():
+            self.assertEqual(ssot_loader.get_operator_symbol(code), symbol)
+
+    def test_falls_back_to_code_when_unknown(self) -> None:
+        self.assertEqual(ssot_loader.get_operator_symbol("NOT_REAL"), "NOT_REAL")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three hardcoded duplicates of SSOT data, found in the earlier cross-repo SSOT-duplication sweep:

_format_operator's GE/GT/LE/LT/EQ/NE→symbol map duplicated OperatorType.yml. Added ssot_loader.get_operator_symbol() (depends on the SSOT synonym-reorder PR) and deleted the map — symbols match exactly, no visual change.
"Sex"/"Stroke Type" were hardcoded in two places (_dimension_label, _axis_label_for_dimension), right next to working get_canonical_display_name() calls for NIHSS/Age/generic fields in the same functions. Routed through SSOT instead — visible label change: axis text becomes "sex type"/"stroke type" (SSOT's first synonym, lowercase), matching how NIHSS/Age labels already render in these exact charts.
ssot_metric_defaults.py's _AXIS_LABEL_OVERRIDES/_AXIS_UNIT_OVERRIDES hardcoded label/unit text for DTN/ONSET_TO_DOOR/DOOR_TO_REPERFUSION in a module whose own docstring claims to be the SSOT single source of truth. Unit override was 100% redundant (SSOT already has it). Label override wasn't exact duplication but the difference was cosmetic ("Door-to-Needle Time" vs. the generic fallback's "Door To Needle", with "Time" redundant against the unit shown right after in parens) — deleted, all three metrics now render through the same path as the other 157.
Regression tests added for all three. Depends on SSOT's operator-symbol-reorder PR merging first.