### PR TITLE
Unify duplicated stat-test keyword lists into one shared constant

### DIFF
--- a/src/planners/langchain/pipeline.py
+++ b/src/planners/langchain/pipeline.py
@@ -40,6 +40,19 @@ _FEWSHOT_ENTITY_KEY_WEIGHT = 6.0
 _FEWSHOT_ENTITY_VALUE_WEIGHT = 10.0
 _FEWSHOT_INTENT_WEIGHT = 8.0
 
+# Shared with request_orchestrator.py's _has_statistical_test_signal() so both
+# places that heuristically detect "does this question want a stat test"
+# agree on the same phrase list, instead of maintaining two that can drift.
+_STAT_TEST_KEYWORDS = (
+    "statistical test",
+    "mann-whitney",
+    "mann whitney",
+    "compare",
+    "significant",
+    "significance",
+    "difference between",
+)
+
 _INTENT_KEYWORDS: Dict[str, List[str]] = {
     "chart_line": ["line", "trend"],
     "chart_bar": ["bar", "column"],
@@ -47,13 +60,7 @@ _INTENT_KEYWORDS: Dict[str, List[str]] = {
     "distribution": ["distribution", "histogram", "violin", "box"],
     "time": ["over time", "last ", "monthly", "weekly", "yearly", "time series"],
     "group_by": [" by ", "grouped by", "split by"],
-    "stat_test": [
-        "compare",
-        "mann-whitney",
-        "statistical test",
-        "significant",
-        "difference between",
-    ],
+    "stat_test": list(_STAT_TEST_KEYWORDS),
 }
 
 _SUPPORTED_STAT_TESTS = ["MANN_WHITNEY_U_TEST"]

--- a/src/planners/langchain/request_orchestrator.py
+++ b/src/planners/langchain/request_orchestrator.py
@@ -14,7 +14,11 @@ from langchain_core.prompts import ChatPromptTemplate
 
 from src.domain.langchain.schema import TIME_INTERVALS, AnalysisPlan, AndFilter, ChartType, DataOriginSpec, DateFilter, MetricSpec, OriginScopeSpec, StatisticalTestSpec
 from src.planners.langchain.llm_factory import create_chat_llm
-from src.planners.langchain.pipeline import _PLANNER_REQUEST_TIMEOUT_SECONDS, generate_analysis_plan
+from src.planners.langchain.pipeline import (
+    _PLANNER_REQUEST_TIMEOUT_SECONDS,
+    _STAT_TEST_KEYWORDS,
+    generate_analysis_plan,
+)
 from src.planners.langchain.prompt_loader import load_prompt_text
 from src.shared import ssot_loader
 from src.util import env as env_util
@@ -119,16 +123,6 @@ _STATISTICAL_COHORT_ENTITY_KEYS = {
     "age",
     "mine",
 }
-
-_STAT_TEST_KEYWORDS = (
-    "statistical test",
-    "mann-whitney",
-    "mann whitney",
-    "compare",
-    "significant",
-    "significance",
-    "difference between",
-)
 
 _PROVIDER_GROUP_HINTS = (
     "provider group",


### PR DESCRIPTION
request_orchestrator.py's pre-LLM routing gate and pipeline.py's few-shot ranking heuristic each kept their own English-only phrase list for "does this question want a stat test," and they'd drifted (pipeline.py was missing "mann whitney" without a hyphen, and "significance"). These aren't canonical-entity resolution like sex/country/metric — they're heuristics several steps upstream of where StatisticalTestType.yml actually canonicalizes things — so this isn't an SSOT migration, just a plain duplication fix. Moved the list to pipeline.py (no dependency cycle risk) as _STAT_TEST_KEYWORDS, request_orchestrator.py now imports it instead of redefining it.