### PR TITLE
refactor: update distribution axis logic for line charts

### DIFF
--- a/src/executors/mapping/chart_builder.py
+++ b/src/executors/mapping/chart_builder.py
@@ -327,14 +327,14 @@ def _uses_distribution_axes(
     if chart_type_upper == ChartType.HISTOGRAM.value:
         return True
 
-    if chart_type_upper != ChartType.BAR.value or dimensions:
+    if chart_type_upper not in {ChartType.BAR.value, ChartType.LINE.value} or dimensions:
         return False
 
     has_points = False
     for item in series:
         for point in item.data:
             has_points = True
-            if _coerce_float(point.x) is None or _coerce_float(point.y) is None:
+            if not isinstance(point.x, (int, float)) or not isinstance(point.y, (int, float)):
                 return False
 
     return has_points

--- a/tests/test_chart_builder.py
+++ b/tests/test_chart_builder.py
@@ -42,6 +42,42 @@ class ChartBuilderTests(unittest.TestCase):
         self.assertEqual(y_axis.label, "Cases")
         self.assertEqual(y_axis.type.value, "linear")
 
+    def test_line_distribution_without_dimensions_uses_metric_and_cases_axes(
+        self,
+    ) -> None:
+        plan_chart = ChartSpec(
+            chart_type="LINE",
+            metrics=[MetricSpec(metric="SYSTOLIC_PRESSURE")],
+        )
+        series = [
+            ChartSeries(
+                name="SYSTOLIC_PRESSURE",
+                data=[
+                    ChartPoint(x=0, y=0),
+                    ChartPoint(x=30, y=15),
+                    ChartPoint(x=60, y=18),
+                ],
+            )
+        ]
+
+        chart = build_chart_dto(
+            plan_chart=plan_chart,
+            dimensions=[],
+            series=series,
+            derived_axes=None,
+        )
+
+        self.assertIsNotNone(chart.metadata.x_axis)
+        self.assertIsNotNone(chart.metadata.y_axis)
+        x_axis = chart.metadata.x_axis
+        y_axis = chart.metadata.y_axis
+        if x_axis is None or y_axis is None:
+            self.fail("Expected both axes to be present")
+        self.assertEqual(x_axis.label, "initial systolic blood pressure (mmHg)")
+        self.assertEqual(x_axis.type.value, "linear")
+        self.assertEqual(y_axis.label, "Cases")
+        self.assertEqual(y_axis.type.value, "linear")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Linecharts had a similar problem as bar charts, flipping labels on requests with no time grain