### PR TITLE
Implement pagination and localization for hospital listings

### DIFF
--- a/src/actions/actions/hospitals_action.py
+++ b/src/actions/actions/hospitals_action.py
@@ -84,6 +84,30 @@ def _tracker_trace_id(tracker: TrackerLike) -> Optional[str]:
     return None
 
 
+def _build_pagination_buttons(*, offset: int, limit: int, total_count: int, language: str) -> List[Dict[str, str]]:
+    buttons: List[Dict[str, str]] = []
+
+    if offset > 0:
+        previous_offset = max(offset - limit, 0)
+        buttons.append(
+            {
+                "title": translate("action.hospitals.previous_page_button", language=language),
+                "payload": f"list hospitals {previous_offset}",
+            }
+        )
+
+    next_offset = offset + limit
+    if next_offset < total_count:
+        buttons.append(
+            {
+                "title": translate("action.hospitals.next_page_button", language=language),
+                "payload": f"list hospitals {next_offset}",
+            }
+        )
+
+    return buttons
+
+
 class ActionListHospitals(Action):  # pyright: ignore
     """List hospitals/providers available for comparison."""
 
@@ -157,12 +181,16 @@ class ActionListHospitals(Action):  # pyright: ignore
                     names = [n for n in names if needle in n.lower()]
 
                 if not names:
-                    no_match_msg = translate("action.hospitals.no_matches_with_hint", language=language) if isinstance(name_filter, str) and name_filter.strip() else translate("action.hospitals.no_matches", language=language)
+                    no_match_msg = (
+                        translate("action.hospitals.no_matches_with_hint", language=language)
+                        if isinstance(name_filter, str) and name_filter.strip()
+                        else translate("action.hospitals.no_matches", language=language)
+                    )
                     dispatcher.utter_message(text=no_match_msg)
                     return []
 
-                preview = ", ".join(names[:10])
-                more_count = max(len(names) - 10, 0)
+                page_size = max(1, int(limit))
+                preview = ", \n".join(names[:page_size])
                 criteria: List[str] = []
                 country_code = filters.get("country_code")
                 sort = filters.get("sort")
@@ -211,17 +239,17 @@ class ActionListHospitals(Action):  # pyright: ignore
                         },
                     )
 
-                more_suffix = (
-                    translate(
-                        "action.hospitals.more_in_page",
-                        language=language,
-                        params={"more_count": more_count},
-                    )
-                    if more_count
-                    else ""
+                text_message = prefix + f"\n{preview}."
+                buttons = _build_pagination_buttons(
+                    offset=offset,
+                    limit=limit,
+                    total_count=total_count,
+                    language=language,
                 )
-                text_message = prefix + f" {preview}." + more_suffix
-                dispatcher.utter_message(text=text_message)
+                message_payload: Dict[str, Any] = {"text": text_message}
+                if buttons:
+                    message_payload["buttons"] = buttons
+                dispatcher.utter_message(**message_payload)
                 return []
             except Exception as exc:
                 logger.exception(

--- a/src/actions/helpers/hospital.py
+++ b/src/actions/helpers/hospital.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, cast
 
+_HOSPITALS_PAGE_SIZE = 50
+
 
 def extract_hospital_filters(tracker: Any) -> Dict[str, Any]:
     tracker_any: Any = tracker
@@ -86,14 +88,28 @@ def extract_hospital_filters(tracker: Any) -> Dict[str, Any]:
 
     limit_val = first_int(
         metadata.get("limit"),
+        entities_by_name.get("limit"),
+        entities_by_name.get("page_size"),
         tracker_any.get_slot("limit"),
     )
     offset_val = first_int(
         metadata.get("offset"),
+        metadata.get("start"),
+        metadata.get("from"),
+        entities_by_name.get("offset"),
+        entities_by_name.get("start"),
+        entities_by_name.get("from"),
+        entities_by_name.get("skip"),
         tracker_any.get_slot("offset"),
     )
 
-    limit = 50 if limit_val is None else max(1, min(limit_val, 200))
+    # Some NLU pipelines route naked numbers like "list hospitals 100" into a
+    # `limit` slot. We use fixed page size and treat that value as the desired
+    # start offset when no explicit offset is available.
+    if offset_val is None and limit_val is not None:
+        offset_val = limit_val
+
+    limit = _HOSPITALS_PAGE_SIZE
     offset = 0 if offset_val is None else max(0, offset_val)
 
     return {

--- a/src/locales/cs/common.json
+++ b/src/locales/cs/common.json
@@ -33,6 +33,8 @@
       "no_matches_with_hint": "Nenašel jsem žádné nemocnice odpovídající vašim filtrům. Zkuste kratší nebo méně specifický název.",
       "summary_with_name_filter": "Na této stránce jsem našel {matched_count} odpovídajících nemocnic (search='{search}', offset={offset}, limit={limit}); celkový počet poskytovatelů před filtrem názvu: {total_count}.",
       "summary_general": "Našel jsem {total_count} nemocnic{criteria_text}; zobrazuji {shown_start}-{shown_end}.",
+      "previous_page_button": "Předchozí",
+      "next_page_button": "Další",
       "criteria_country": "země={country}",
       "criteria_sort": "řazení={sort}",
       "more_in_page": " (+{more_count} dalších na této stránce)",

--- a/src/locales/el/common.json
+++ b/src/locales/el/common.json
@@ -33,6 +33,8 @@
       "no_matches_with_hint": "Δεν βρήκα νοσοκομεία που να ταιριάζουν με τα φίλτρα σας. Δοκιμάστε πιο σύντομο ή λιγότερο συγκεκριμένο όνομα.",
       "summary_with_name_filter": "Βρήκα {matched_count} νοσοκομεία που ταιριάζουν σε αυτή τη σελίδα (αναζήτηση='{search}', offset={offset}, limit={limit}); σύνολο παρόχων πριν από το φίλτρο ονόματος: {total_count}.",
       "summary_general": "Βρήκα {total_count} νοσοκομεία{criteria_text}; εμφανίζονται {shown_start}-{shown_end}.",
+      "previous_page_button": "Προηγούμενα",
+      "next_page_button": "Επόμενα",
       "criteria_country": "χώρα={country}",
       "criteria_sort": "ταξινόμηση={sort}",
       "more_in_page": " (+{more_count} ακόμη σε αυτή τη σελίδα)",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -36,6 +36,8 @@
       "no_matches_with_hint": "I couldn't find any hospitals matching your filters. Try a shorter or less specific name.",
       "summary_with_name_filter": "I found {matched_count} matching hospitals on this page (search='{search}', offset={offset}, limit={limit}); total providers before name filter: {total_count}.",
       "summary_general": "I found {total_count} hospitals{criteria_text}; showing {shown_start}-{shown_end}.",
+      "previous_page_button": "Previous",
+      "next_page_button": "Next",
       "criteria_country": "country={country}",
       "criteria_sort": "sort={sort}",
       "more_in_page": " (+{more_count} more in this page)",

--- a/tests/test_hospitals_action.py
+++ b/tests/test_hospitals_action.py
@@ -1,0 +1,61 @@
+from src.actions.actions.hospitals_action import _build_pagination_buttons
+from src.actions.helpers.hospital import extract_hospital_filters
+
+
+class _StubTracker:
+    def __init__(self, latest_message, slots=None):
+        self.latest_message = latest_message
+        self._slots = slots or {}
+
+    def get_slot(self, key):
+        return self._slots.get(key)
+
+
+def test_extract_hospital_filters_treats_numeric_limit_like_offset_with_fixed_page_size() -> None:
+    tracker = _StubTracker(
+        latest_message={"metadata": {"limit": 100}, "entities": []},
+        slots={},
+    )
+
+    filters = extract_hospital_filters(tracker)
+
+    assert filters["limit"] == 50
+    assert filters["offset"] == 100
+
+
+def test_extract_hospital_filters_uses_explicit_offset_when_present() -> None:
+    tracker = _StubTracker(
+        latest_message={"metadata": {"limit": 100, "offset": 50}, "entities": []},
+        slots={},
+    )
+
+    filters = extract_hospital_filters(tracker)
+
+    assert filters["limit"] == 50
+    assert filters["offset"] == 50
+
+
+def test_build_pagination_buttons_first_page_has_only_next() -> None:
+    buttons = _build_pagination_buttons(offset=0, limit=50, total_count=120, language="en")
+
+    assert len(buttons) == 1
+    assert buttons[0]["title"] == "Next"
+    assert buttons[0]["payload"] == "list hospitals 50"
+
+
+def test_build_pagination_buttons_middle_page_has_previous_and_next() -> None:
+    buttons = _build_pagination_buttons(offset=50, limit=50, total_count=180, language="en")
+
+    assert len(buttons) == 2
+    assert buttons[0]["title"] == "Previous"
+    assert buttons[0]["payload"] == "list hospitals 0"
+    assert buttons[1]["title"] == "Next"
+    assert buttons[1]["payload"] == "list hospitals 100"
+
+
+def test_build_pagination_buttons_last_page_has_only_previous() -> None:
+    buttons = _build_pagination_buttons(offset=100, limit=50, total_count=120, language="en")
+
+    assert len(buttons) == 1
+    assert buttons[0]["title"] == "Previous"
+    assert buttons[0]["payload"] == "list hospitals 50"


### PR DESCRIPTION
This pull request improves hospital listing pagination and filtering, making the user experience clearer and more consistent. The main changes include introducing pagination buttons, standardizing page size, and updating logic for interpreting numeric parameters. The changes are covered by new tests and updated translations.

**Pagination and Filtering Improvements:**

* Added a `_build_pagination_buttons` helper in `hospitals_action.py` to generate "Previous" and "Next" navigation buttons for hospital lists, with localized titles and correct payloads.
* Changed the page size for hospital listings to a fixed value (`_HOSPITALS_PAGE_SIZE = 50`), and updated logic so that a numeric `limit` with no explicit offset is treated as the desired start offset, not the page size. [[1]](diffhunk://#diff-e6f474a120888040459bc2ab3a9a6527370cd8e217588352c42debbedc86c976R5-R6) [[2]](diffhunk://#diff-e6f474a120888040459bc2ab3a9a6527370cd8e217588352c42debbedc86c976R91-R112)
* Updated the hospital list display to use the fixed page size, show results separated by newlines, and include pagination buttons in the response payload. [[1]](diffhunk://#diff-f94dcb1b59ea291a07b07cc327bee88eee327e789235e83aaa905d2312fa4d71L160-R193) [[2]](diffhunk://#diff-f94dcb1b59ea291a07b07cc327bee88eee327e789235e83aaa905d2312fa4d71L214-R252)

**Localization:**

* Added translations for "Previous" and "Next" page buttons in English, Czech, and Greek locale files. [[1]](diffhunk://#diff-90cc22e42d25a866b056a59abd1eb6b7ad4ce4ea8fa42c729eed6aadb4f91653R39-R40) [[2]](diffhunk://#diff-dc965dd0b2b742edc7225a9a3d30dd49000519890880c538c6da8c415da845f5R36-R37) [[3]](diffhunk://#diff-71392e89ceb00c4a8b1260a389a35da8fb2953181ea6872d2636085b1c06ec34R36-R37)

**Testing:**

* Added tests to verify new pagination logic and the interpretation of numeric parameters in `test_hospitals_action.py`.