### PR TITLE
Add histogram bin width calculation and update final bin logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==22.1.0
 aiohappyeyeballs==2.6.1
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.9.0

--- a/src/executors/mapping/chart_builder.py
+++ b/src/executors/mapping/chart_builder.py
@@ -62,6 +62,24 @@ def _quantile(sorted_values: List[float], q: float) -> float:
     return sorted_values[low] * (1.0 - weight) + sorted_values[high] * weight
 
 
+def _histogram_bin_width_from_points(points: List[Any]) -> float:
+    if len(points) < 2:
+        return 0.0
+
+    deltas: List[float] = []
+    previous = _coerce_float(points[0].x)
+    for point in points[1:]:
+        current = _coerce_float(point.x)
+        delta = current - previous
+        if delta > 0:
+            deltas.append(delta)
+        previous = current
+
+    if not deltas:
+        return 0.0
+    return deltas[-1]
+
+
 def _dimension_label(dimension: Dimension) -> Optional[str]:
     if isinstance(dimension.spec, GroupByTime):
         grain = getattr(dimension.spec, "grain", None)
@@ -478,14 +496,21 @@ def build_chart_dto(
         bins: List[HistogramBin] = []
         source = series[0].data if series else []
         if source:
+            inferred_width = _histogram_bin_width_from_points(source)
             for idx, point in enumerate(source):
                 start = _coerce_float(point.x)
-                end = start
                 if idx + 1 < len(source):
                     end = _coerce_float(source[idx + 1].x)
+                else:
+                    end = start + inferred_width if inferred_width > 0 else start
                 freq = _coerce_float(point.y)
                 bins.append(HistogramBin(range_start=start, range_end=end, frequency=freq))
-        return Histogram(metadata=metadata, data=bins, bin_count=max(1, len(bins)))
+        return Histogram(
+            metadata=metadata,
+            data=bins,
+            bin_count=max(1, len(bins)),
+            bin_width=inferred_width if source else None,
+        )
     if chart_type_upper == ChartType.BOX.value:
         values = sorted(_flatten_y_values(series))
         if not values:

--- a/tests/test_chart_builder_semantics.py
+++ b/tests/test_chart_builder_semantics.py
@@ -1,7 +1,6 @@
 import unittest
 
-from src.domain.dto.charts.types import ChartPoint
-from src.domain.dto.charts.types import ChartSeries
+from src.domain.dto.charts.types import ChartPoint, ChartSeries
 from src.domain.langchain import schema as S
 from src.executors.mapping.chart_builder import build_chart_dto
 from src.executors.planning.query_compiler import compile_chart_grouping
@@ -91,6 +90,38 @@ class ChartBuilderSemanticsTests(unittest.TestCase):
             )
 
         self.assertIn("Expected numeric chart value", str(err.exception))
+
+    def test_histogram_uses_consecutive_bin_intervals_for_final_bin(self) -> None:
+        chart = S.ChartSpec(
+            chart_type="HISTOGRAM",
+            metrics=[S.MetricSpec(metric="DTN")],
+            semantics=S.AnalysisSemanticsSpec(
+                intent="DISTRIBUTION",
+                measure=S.MeasureSemanticsSpec(type="DISTRIBUTION"),
+            ),
+        )
+
+        dto = build_chart_dto(
+            plan_chart=chart,
+            dimensions=[],
+            series=[
+                ChartSeries(
+                    name="DTN",
+                    data=[
+                        ChartPoint.model_construct(x=30, y=4),
+                        ChartPoint.model_construct(x=33, y=5),
+                        ChartPoint.model_construct(x=36, y=6),
+                        ChartPoint.model_construct(x=39, y=8),
+                    ],
+                )
+            ],
+            derived_axes=None,
+        )
+
+        self.assertEqual(len(dto.data), 4)
+        self.assertEqual(dto.data[-1].range_start, 39.0)
+        self.assertEqual(dto.data[-1].range_end, 42.0)
+        self.assertEqual(dto.bin_width, 3.0)
 
     def test_pie_chart_raises_on_non_numeric_slice_value(self) -> None:
         chart = S.ChartSpec(


### PR DESCRIPTION
Histogram Bin DTO's would label the final bin with an incorrect range_end, making equal to range_start. Instead it will now infer a width and assign an appropriate range_end.