### PR TITLE
Enhance origin scope resolution and improve GraphQL error handling

### DIFF
--- a/src/executors/analytics_center/client.py
+++ b/src/executors/analytics_center/client.py
@@ -89,6 +89,7 @@ class CountryCollectionResult(TypedDict):
 class MineScopeResult(TypedDict, total=False):
     provider_id: int
     provider_group_id: int
+    label: str
 
 
 class AnalyticsCenterClient:
@@ -629,13 +630,25 @@ class AnalyticsCenterClient:
         provider = cast(Dict[str, Any], provider_any) if isinstance(provider_any, dict) else {}
         provider_id = self._as_int(provider.get("id"))
         if provider_id is not None:
-            return {"provider_id": provider_id}
+            result: MineScopeResult = {"provider_id": provider_id}
+            for name_key in ("nameEnglish", "nameNative", "shortName", "name"):
+                name_val = provider.get(name_key)
+                if isinstance(name_val, str) and name_val.strip():
+                    result["label"] = name_val.strip()
+                    break
+            return result
 
         group_any = settings.get("currentProviderGroup")
         group = cast(Dict[str, Any], group_any) if isinstance(group_any, dict) else {}
         group_id = self._as_int(group.get("id"))
         if group_id is not None:
-            return {"provider_group_id": group_id}
+            group_result: MineScopeResult = {"provider_group_id": group_id}
+            for name_key in ("fullName", "name", "shortName", "title"):
+                name_val = group.get(name_key)
+                if isinstance(name_val, str) and name_val.strip():
+                    group_result["label"] = name_val.strip()
+                    break
+            return group_result
 
         return None
 

--- a/src/executors/mapping/chart_builder.py
+++ b/src/executors/mapping/chart_builder.py
@@ -337,7 +337,7 @@ def _uses_distribution_axes(
     if chart_type_upper == ChartType.HISTOGRAM.value:
         return True
 
-    if chart_type_upper not in {ChartType.BAR.value, ChartType.LINE.value} or dimensions:
+    if chart_type_upper not in {ChartType.BAR.value, ChartType.LINE.value}:  # or dimensions:
         return False
 
     has_points = False

--- a/src/executors/planning/metric_request_factory.py
+++ b/src/executors/planning/metric_request_factory.py
@@ -19,8 +19,6 @@ def _metric_scope_label(metric: S.MetricSpec) -> Optional[str]:
         return scope.label.strip()
 
     scope_type = (scope.scope_type or "").strip().lower()
-    if scope_type == "mine":
-        return "My Hospital"
     if scope_type == "country_average":
         if isinstance(scope.value, str) and scope.value.strip():
             return f"National Mean ({scope.value.strip()})"

--- a/src/executors/planning/origin_scope_resolver.py
+++ b/src/executors/planning/origin_scope_resolver.py
@@ -25,9 +25,7 @@ def _parse_max_provider_ids(raw: str) -> int:
 
 _MAX_PROVIDER_IDS = _parse_max_provider_ids(_MAX_PROVIDER_IDS_RAW)
 
-_PROVIDER_CACHE_TTL_SECONDS_RAW = (
-    env_util.get_env("EXECUTOR_PROVIDER_CACHE_TTL_SECONDS", default="300") or "300"
-)
+_PROVIDER_CACHE_TTL_SECONDS_RAW = env_util.get_env("EXECUTOR_PROVIDER_CACHE_TTL_SECONDS", default="300") or "300"
 
 
 def _parse_provider_cache_ttl_seconds(raw: str) -> int:
@@ -37,9 +35,7 @@ def _parse_provider_cache_ttl_seconds(raw: str) -> int:
         return 300
 
 
-_PROVIDER_CACHE_TTL_SECONDS = _parse_provider_cache_ttl_seconds(
-    _PROVIDER_CACHE_TTL_SECONDS_RAW
-)
+_PROVIDER_CACHE_TTL_SECONDS = _parse_provider_cache_ttl_seconds(_PROVIDER_CACHE_TTL_SECONDS_RAW)
 _MAX_PROVIDER_CACHE_ENTRIES = 64
 _PROVIDER_LIST_CACHE: Dict[tuple[str, str, str], tuple[float, List[Dict[str, Any]]]] = {}
 
@@ -405,12 +401,8 @@ def _search_accessible_providers_by_name(
     client = get_analytics_center_client()
     matched: List[Dict[str, Any]] = []
     seen_ids: set[int] = set()
-    exact_found: Dict[str, bool] = {
-        requested: False for requested in requested_names
-    }
-    requested_norms = {
-        requested: _normalize_text(requested) for requested in requested_names
-    }
+    exact_found: Dict[str, bool] = {requested: False for requested in requested_names}
+    requested_norms = {requested: _normalize_text(requested) for requested in requested_names}
     offset = 0
     limit = 200
 
@@ -420,6 +412,7 @@ def _search_accessible_providers_by_name(
                 user_sub=user_sub,
                 trace_id=trace_id,
                 country_code=country_code,
+                user=user_sub,
                 limit=limit,
                 offset=offset,
                 raise_on_error=True,
@@ -548,25 +541,27 @@ def _list_accessible_provider_groups(user_sub: str, trace_id: str, country_code:
     return out[:_MAX_PROVIDER_IDS]
 
 
-def _resolve_mine_scope(user_sub: str, trace_id: str) -> Optional[S.DataOriginSpec]:
+def _resolve_mine_scope(user_sub: str, trace_id: str) -> tuple[Optional[S.DataOriginSpec], Optional[str]]:
     client = get_analytics_center_client()
     try:
         scope = client.resolve_my_default_scope(user_sub=user_sub, trace_id=trace_id, raise_on_error=True)
     except AnalyticsCenterError as exc:
         _raise_if_auth_session_error(exc)
-        return None
+        return None, None
     if not isinstance(scope, dict):
-        return None
+        return None, None
+
+    label: Optional[str] = scope.get("label") or None
 
     provider_id_any = scope.get("provider_id")
     if isinstance(provider_id_any, int):
-        return S.DataOriginSpec(providerId=[provider_id_any])
+        return S.DataOriginSpec(providerId=[provider_id_any]), label
 
     provider_group_id_any = scope.get("provider_group_id")
     if isinstance(provider_group_id_any, int):
-        return S.DataOriginSpec(providerGroupId=[provider_group_id_any])
+        return S.DataOriginSpec(providerGroupId=[provider_group_id_any]), label
 
-    return None
+    return None, None
 
 
 def _resolve_provider_name(value: Any, user_sub: str, trace_id: str) -> S.DataOriginSpec:
@@ -834,7 +829,7 @@ def _infer_country_code_from_data_origin(data_origin: S.DataOriginSpec, user_sub
 
 
 def _infer_user_country_code(user_sub: str, trace_id: str) -> Optional[str]:
-    mine_scope = _resolve_mine_scope(user_sub=user_sub, trace_id=trace_id)
+    mine_scope, _ = _resolve_mine_scope(user_sub=user_sub, trace_id=trace_id)
     if mine_scope is None:
         return None
     return _infer_country_code_from_data_origin(data_origin=mine_scope, user_sub=user_sub, trace_id=trace_id)
@@ -845,37 +840,37 @@ def _resolve_scope(
     user_sub: str,
     trace_id: str,
     inferred_country_code: Optional[str] = None,
-) -> Optional[S.DataOriginSpec]:
+) -> tuple[Optional[S.DataOriginSpec], Optional[str]]:
     scope_type = (scope.scope_type or "").strip().lower()
     value = scope.value
 
     if scope_type == "mine":
-        resolved = _resolve_mine_scope(user_sub=user_sub, trace_id=trace_id)
+        resolved, mine_label = _resolve_mine_scope(user_sub=user_sub, trace_id=trace_id)
         if resolved is None:
             raise OriginScopeResolutionError(
                 "I could not resolve your default hospital scope right now.",
                 clarification_type="mine",
             )
-        return resolved
+        return resolved, mine_label
 
     if scope_type == "provider_id":
         if isinstance(value, int):
-            return S.DataOriginSpec(providerId=[value])
+            return S.DataOriginSpec(providerId=[value]), None
         if isinstance(value, str) and value.strip().isdigit():
-            return S.DataOriginSpec(providerId=[int(value.strip())])
+            return S.DataOriginSpec(providerId=[int(value.strip())]), None
         raise OriginScopeResolutionError(
             "Provider scope requires a numeric provider ID.",
             clarification_type="provider_id",
         )
 
     if scope_type == "provider_name":
-        return _resolve_provider_name(value=value, user_sub=user_sub, trace_id=trace_id)
+        return _resolve_provider_name(value=value, user_sub=user_sub, trace_id=trace_id), None
 
     if scope_type == "provider_group_id":
         if isinstance(value, int):
-            return S.DataOriginSpec(providerGroupId=[value])
+            return S.DataOriginSpec(providerGroupId=[value]), None
         if isinstance(value, str) and value.strip().isdigit():
-            return S.DataOriginSpec(providerGroupId=[int(value.strip())])
+            return S.DataOriginSpec(providerGroupId=[int(value.strip())]), None
         raise OriginScopeResolutionError(
             "Provider-group scope requires a numeric group ID.",
             clarification_type="provider_group_id",
@@ -887,7 +882,7 @@ def _resolve_scope(
             country_code=scope.country_code or inferred_country_code,
             user_sub=user_sub,
             trace_id=trace_id,
-        )
+        ), None
 
     if scope_type == "country_average":
         return _resolve_country_scope(
@@ -895,7 +890,7 @@ def _resolve_scope(
             country_code=scope.country_code or inferred_country_code,
             user_sub=user_sub,
             trace_id=trace_id,
-        )
+        ), None
 
     if scope_type == "all_accessible":
         providers = _list_accessible_providers(user_sub=user_sub, trace_id=trace_id)
@@ -905,11 +900,11 @@ def _resolve_scope(
             if provider_id is not None and provider_id not in provider_ids:
                 provider_ids.append(provider_id)
         if not provider_ids:
-            return None
-        return S.DataOriginSpec(providerId=provider_ids)
+            return None, None
+        return S.DataOriginSpec(providerId=provider_ids), None
 
     if scope_type == "provider_group_name":
-        return _resolve_provider_group_name(value=value, user_sub=user_sub, trace_id=trace_id)
+        return _resolve_provider_group_name(value=value, user_sub=user_sub, trace_id=trace_id), None
 
     raise OriginScopeResolutionError(
         f"Unsupported origin scope type: {scope_type}",
@@ -945,7 +940,7 @@ def _resolve_metric_origin(
 
     if scope_ref is not None:
         try:
-            resolved_data_origin = _resolve_scope(
+            resolved_data_origin, resolved_scope_label = _resolve_scope(
                 scope=scope_ref,
                 user_sub=user_sub,
                 trace_id=trace_id,
@@ -969,6 +964,7 @@ def _resolve_metric_origin(
                 ),
             )
             resolved_data_origin = None
+            resolved_scope_label = None
         except Exception:
             if not fail_open_for_metric:
                 raise OriginScopeResolutionError("Origin scope resolution failed unexpectedly.")
@@ -987,11 +983,19 @@ def _resolve_metric_origin(
                 ),
             )
             resolved_data_origin = None
+            resolved_scope_label = None
+    else:
+        resolved_scope_label = None
+
+    if scope_ref is not None and isinstance(resolved_scope_label, str) and resolved_scope_label.strip():
+        resolved_scope_ref = scope_ref.model_copy(update={"label": resolved_scope_label.strip()})
+    else:
+        resolved_scope_ref = scope_ref
 
     return S.MetricSpec(
         metric=metric.metric,
         dataOrigin=resolved_data_origin,
-        originScope=scope_ref,
+        originScope=resolved_scope_ref,
     )
 
 

--- a/src/executors/transport/request_runner.py
+++ b/src/executors/transport/request_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+from collections import Counter
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from src.domain.dto.charts.types import ChartSeries
@@ -14,6 +15,47 @@ from src.util.logging_utils import log_context
 logger = logging.getLogger(__name__)
 
 GraphQLQueryCallback = Callable[[Dict[str, Any]], None]
+
+
+def _summarize_graphql_errors(errors: List[Any], sample_limit: int = 5) -> Dict[str, Any]:
+    message_counts: Counter[str] = Counter()
+    code_counts: Counter[str] = Counter()
+    path_counts: Counter[str] = Counter()
+    samples: List[Dict[str, str]] = []
+
+    for err in errors:
+        if not isinstance(err, dict):
+            continue
+
+        message_raw = err.get("message")
+        message = str(message_raw).strip() if message_raw is not None else ""
+        if not message:
+            message = "(no message)"
+        message_counts[message] += 1
+
+        extensions = err.get("extensions")
+        code: Optional[str] = None
+        if isinstance(extensions, dict):
+            code_raw = extensions.get("code")
+            if isinstance(code_raw, str) and code_raw.strip():
+                code = code_raw.strip()
+        code_counts[code or "-"] += 1
+
+        path_raw = err.get("path")
+        path_label = "-"
+        if isinstance(path_raw, list) and path_raw:
+            path_label = ".".join(str(part) for part in path_raw)
+        path_counts[path_label] += 1
+
+        if len(samples) < sample_limit:
+            samples.append({"message": message, "code": code or "-", "path": path_label})
+
+    return {
+        "message_counts": dict(message_counts),
+        "code_counts": dict(code_counts),
+        "path_counts": dict(path_counts),
+        "sample": samples,
+    }
 
 
 def _runner_log_context(
@@ -165,10 +207,14 @@ async def run_graphql_request(
 
     if getattr(resp, "errors", None):
         request_failures.append("graphql_error")
-        error_count = len(resp.errors or [])
+        errors = cast(List[Any], resp.errors or [])
+        error_count = len(errors)
+        error_summary = _summarize_graphql_errors(errors)
         logger.error(
-            "[plan_executor] GraphQL errors returned (count=%s)",
+            "[plan_executor] GraphQL errors returned (count=%s, unique_messages=%s, unique_codes=%s)",
             error_count,
+            len(error_summary["message_counts"]),
+            len(error_summary["code_counts"]),
             extra=_runner_log_context(
                 event="request_runner.graphql_errors_returned",
                 outcome="failure",
@@ -176,6 +222,10 @@ async def run_graphql_request(
                 query_hash=q_hash,
                 group_by_field=group_by_field,
                 error_count=error_count,
+                error_message_counts=error_summary["message_counts"],
+                error_code_counts=error_summary["code_counts"],
+                error_path_counts=error_summary["path_counts"],
+                error_samples=error_summary["sample"],
             ),
         )
 
@@ -207,10 +257,7 @@ async def run_graphql_request(
         if kpi_groups is None:
             continue
         if not isinstance(kpi_groups, list):
-            raise ValueError(
-                "Invalid GraphQL metrics payload: "
-                f"metric {metric_alias!r} has non-list kpi_group"
-            )
+            raise ValueError(f"Invalid GraphQL metrics payload: metric {metric_alias!r} has non-list kpi_group")
         kpi_group_count += len(kpi_groups)
 
     series = map_metrics_payload_to_series(
@@ -229,10 +276,7 @@ async def run_graphql_request(
         if kpi_groups is None:
             continue
         if not isinstance(kpi_groups, list):
-            raise ValueError(
-                "Invalid GraphQL metrics payload: "
-                f"metric {metric_alias!r} has non-list kpi_group"
-            )
+            raise ValueError(f"Invalid GraphQL metrics payload: metric {metric_alias!r} has non-list kpi_group")
         for kpi in cast(List[object], kpi_groups):
             if getattr(kpi, "kpi1", None) is None:
                 skipped_rows += 1
@@ -246,7 +290,7 @@ async def run_graphql_request(
                 if skipped_rows > 0:
                     detail_bits.append(f"{skipped_rows}/{total_rows} row(s) were omitted")
                 if getattr(resp, "errors", None):
-                    detail_bits.append("the backend returned validation errors")
+                    detail_bits.append("the backend returned GraphQL errors")
                 _append_warning(f"Partial data returned for {request_label}; {' and '.join(detail_bits)}.")
             else:
                 _append_warning(f"No usable data was returned for {request_label}; 0/{total_rows} row(s) had valid data.")
@@ -278,7 +322,7 @@ async def run_graphql_request(
         if skipped_rows > 0:
             warning_bits.append(f"{skipped_rows}/{total_rows} row(s) were omitted")
         if has_graphql_errors:
-            warning_bits.append("the backend returned validation errors")
+            warning_bits.append("the backend returned GraphQL errors")
 
         warning_text = f"Partial data returned for {request_label}; {' and '.join(warning_bits)}."
         _append_warning(warning_text)

--- a/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_country_average.json
+++ b/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_country_average.json
@@ -53,7 +53,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           },

--- a/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_named_hospital_quarterly_line.json
+++ b/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_named_hospital_quarterly_line.json
@@ -60,7 +60,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           },

--- a/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_provider_group_name.json
+++ b/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_provider_group_name.json
@@ -53,7 +53,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           },

--- a/src/planners/langchain/fewshot_examples/mw_my_hospital_vs_national.json
+++ b/src/planners/langchain/fewshot_examples/mw_my_hospital_vs_national.json
@@ -25,7 +25,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           },

--- a/src/planners/langchain/fewshot_examples/statistical_test_dtn_by_quarter.json
+++ b/src/planners/langchain/fewshot_examples/statistical_test_dtn_by_quarter.json
@@ -28,7 +28,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           },
@@ -38,7 +37,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           }
@@ -69,7 +67,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           },
@@ -79,7 +76,6 @@
             "origin_scope": {
               "scope_type": "mine",
               "value": null,
-              "label": "My hospital",
               "country_code": null
             }
           }

--- a/src/planners/langchain/request_orchestrator.py
+++ b/src/planners/langchain/request_orchestrator.py
@@ -238,6 +238,7 @@ def _generate_plan_with_timeout(
     progress_cb: Optional[Callable[[str], None]] = None,
 ) -> AnalysisPlan:
     """Wrap generate_analysis_plan with timeout protection to prevent indefinite hangs."""
+
     def _call_plan_gen() -> AnalysisPlan:
         result = generate_analysis_plan(
             question=question,
@@ -251,16 +252,14 @@ def _generate_plan_with_timeout(
         if not isinstance(result, AnalysisPlan):
             raise RuntimeError(f"Expected AnalysisPlan but got {type(result).__name__}")
         return cast(AnalysisPlan, result)
-    
+
     with ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(_call_plan_gen)
         try:
             return future.result(timeout=_PLAN_GENERATION_TIMEOUT_SECONDS)
         except FuturesTimeoutError as exc:
             future.cancel()
-            raise TimeoutError(
-                f"Plan generation timed out after {_PLAN_GENERATION_TIMEOUT_SECONDS:.1f}s for question: {question[:50]}"
-            ) from exc
+            raise TimeoutError(f"Plan generation timed out after {_PLAN_GENERATION_TIMEOUT_SECONDS:.1f}s for question: {question[:50]}") from exc
 
 
 def _metric_candidates(question: str, limit: int = 8) -> List[str]:
@@ -470,9 +469,30 @@ def _extract_iso_day_tokens(entities: Dict[str, Any]) -> List[str]:
 def _extract_period_tokens(entities: Dict[str, Any]) -> List[str]:
     tokens: List[str] = []
     month_names = (
-        "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE",
-        "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER",
-        "JAN", "FEB", "MAR", "APR", "JUN", "JUL", "AUG", "SEP", "SEPT", "OCT", "NOV", "DEC",
+        "JANUARY",
+        "FEBRUARY",
+        "MARCH",
+        "APRIL",
+        "MAY",
+        "JUNE",
+        "JULY",
+        "AUGUST",
+        "SEPTEMBER",
+        "OCTOBER",
+        "NOVEMBER",
+        "DECEMBER",
+        "JAN",
+        "FEB",
+        "MAR",
+        "APR",
+        "JUN",
+        "JUL",
+        "AUG",
+        "SEP",
+        "SEPT",
+        "OCT",
+        "NOV",
+        "DEC",
     )
     month_pattern = "(?:" + "|".join(month_names) + ")"
 
@@ -491,9 +511,15 @@ def _extract_period_tokens(entities: Dict[str, Any]) -> List[str]:
             tokens.append(token)
             continue
         if token in {
-            "THIS YEAR", "LAST YEAR", "PREVIOUS YEAR",
-            "THIS QUARTER", "LAST QUARTER", "PREVIOUS QUARTER",
-            "THIS MONTH", "LAST MONTH", "PREVIOUS MONTH",
+            "THIS YEAR",
+            "LAST YEAR",
+            "PREVIOUS YEAR",
+            "THIS QUARTER",
+            "LAST QUARTER",
+            "PREVIOUS QUARTER",
+            "THIS MONTH",
+            "LAST MONTH",
+            "PREVIOUS MONTH",
         }:
             tokens.append(token)
 
@@ -584,11 +610,7 @@ def _validate_statistical_test_support(question: str) -> Optional[VisualizationR
     return VisualizationRequestOutcome(
         decision="reject",
         reason="unsupported_statistical_test",
-        message=(
-            f"I can't run a {unsupported_name} test yet -- Mann-Whitney U is the only "
-            "statistical test currently supported. Ask me to compare two cohorts with "
-            "a Mann-Whitney U test instead."
-        ),
+        message=(f"I can't run a {unsupported_name} test yet -- Mann-Whitney U is the only statistical test currently supported. Ask me to compare two cohorts with a Mann-Whitney U test instead."),
         clarification_type=None,
         clarification_options=[],
         missing_fields=[],
@@ -749,9 +771,7 @@ def _validate_group_by_support(question: str, entities: Dict[str, Any]) -> Optio
         decision="clarify",
         reason="unsupported_group_by_dimension",
         message=(
-            f"I can't group or split a chart by {names} yet. I can group by stroke type, "
-            "sex, time period (month/quarter/year), EMS prenotification, first contact "
-            "place, IVT department, or INR mode."
+            f"I can't group or split a chart by {names} yet. I can group by stroke type, sex, time period (month/quarter/year), EMS prenotification, first contact place, IVT department, or INR mode."
         ),
         clarification_type="analysis_plan",
         clarification_options=[],
@@ -772,10 +792,7 @@ def _validate_statistical_entity_readiness(question: str, entities: Dict[str, An
         return VisualizationRequestOutcome(
             decision="clarify",
             reason="missing_provider_group_cohorts",
-            message=(
-                "Your request mentions provider groups, but I do not have two provider-group cohorts. "
-                "Please provide provider group A and provider group B explicitly."
-            ),
+            message=("Your request mentions provider groups, but I do not have two provider-group cohorts. Please provide provider group A and provider group B explicitly."),
             clarification_type="analysis_plan",
             clarification_options=[],
             missing_fields=["provider_group_id"],
@@ -785,10 +802,7 @@ def _validate_statistical_entity_readiness(question: str, entities: Dict[str, An
         return VisualizationRequestOutcome(
             decision="clarify",
             reason="missing_provider_cohorts",
-            message=(
-                "Your request mentions providers, but I do not have two provider cohorts. "
-                "Please provide provider A and provider B explicitly."
-            ),
+            message=("Your request mentions providers, but I do not have two provider cohorts. Please provide provider A and provider B explicitly."),
             clarification_type="analysis_plan",
             clarification_options=[],
             missing_fields=["provider_id"],
@@ -802,10 +816,7 @@ def _validate_statistical_entity_readiness(question: str, entities: Dict[str, An
         return VisualizationRequestOutcome(
             decision="clarify",
             reason="missing_statistical_cohorts",
-            message=(
-                "I can run this statistical test only with two explicit cohorts. "
-                "Please provide cohort A and cohort B (for example two providers or provider groups)."
-            ),
+            message=("I can run this statistical test only with two explicit cohorts. Please provide cohort A and cohort B (for example two providers or provider groups)."),
             clarification_type="analysis_plan",
             clarification_options=[],
             missing_fields=["statistical_cohorts"],
@@ -1006,10 +1017,7 @@ def _validate_statistical_plan_readiness(plan: AnalysisPlan) -> Optional[Visuali
             return VisualizationRequestOutcome(
                 decision="clarify",
                 reason="missing_statistical_cohorts",
-                message=(
-                    "I can run Mann-Whitney U only with two explicit cohorts. "
-                    "Please provide cohort A and cohort B to compare."
-                ),
+                message=("I can run Mann-Whitney U only with two explicit cohorts. Please provide cohort A and cohort B to compare."),
                 clarification_type="analysis_plan",
                 clarification_options=[],
                 missing_fields=["statistical_cohorts"],
@@ -1020,10 +1028,7 @@ def _validate_statistical_plan_readiness(plan: AnalysisPlan) -> Optional[Visuali
             return VisualizationRequestOutcome(
                 decision="clarify",
                 reason="missing_statistical_cohorts",
-                message=(
-                    "Mann-Whitney U requires two distinct cohorts. Please provide "
-                    "different cohort filters or scopes for each comparison group."
-                ),
+                message=("Mann-Whitney U requires two distinct cohorts. Please provide different cohort filters or scopes for each comparison group."),
                 clarification_type="analysis_plan",
                 clarification_options=[],
                 missing_fields=["statistical_cohorts"],
@@ -1077,11 +1082,7 @@ def _decision_stage(
     )
 
     # Deterministic safeguard: do not block statistical-test requests on chart_type.
-    if (
-        outcome.decision == "clarify"
-        and _is_missing_chart_type_only(outcome.missing_fields)
-        and _has_statistical_test_signal(question, entities)
-    ):
+    if outcome.decision == "clarify" and _is_missing_chart_type_only(outcome.missing_fields) and _has_statistical_test_signal(question, entities):
         return VisualizationRequestOutcome(
             decision="proceed",
             reason="statistical_test_without_chart_type",
@@ -1211,7 +1212,7 @@ def orchestrate_visualization_request(
             logger.info("Starting validation of statistical plan readiness")
             stats_validation = _validate_statistical_plan_readiness(plan)
             logger.info("Statistical validation complete", extra={"validation_result": stats_validation is not None})
-            
+
             if stats_validation is not None:
                 logger.info("Returning statistical validation result")
                 return stats_validation
@@ -1267,9 +1268,7 @@ def orchestrate_visualization_request(
                 decision="clarify",
                 reason="orchestrator_failed",
                 message=(
-                    "I could not produce a valid statistical plan from that request. "
-                    "Please provide a metric, two explicit cohorts (for example two provider groups), "
-                    "and explicit date bounds."
+                    "I could not produce a valid statistical plan from that request. Please provide a metric, two explicit cohorts (for example two provider groups), and explicit date bounds."
                     if _has_statistical_test_signal(question, entities)
                     else "I need a bit more detail before I can continue."
                 ),

--- a/tests/test_chart_builder.py
+++ b/tests/test_chart_builder.py
@@ -1,7 +1,7 @@
 import unittest
 
 from src.domain.dto.charts.types import ChartPoint, ChartSeries
-from src.domain.langchain.schema import ChartSpec, GroupBySex, GroupByStrokeType, MetricSpec
+from src.domain.langchain.schema import ChartSpec, GroupByAge, GroupBySex, GroupByStrokeType, MetricSpec
 from src.executors.mapping.chart_builder import (
     _axis_label_for_dimension,
     _dimension_label,
@@ -82,6 +82,41 @@ class ChartBuilderTests(unittest.TestCase):
         if x_axis is None or y_axis is None:
             self.fail("Expected both axes to be present")
         self.assertEqual(x_axis.label, "initial systolic blood pressure (mmHg)")
+        self.assertEqual(x_axis.type.value, "linear")
+        self.assertEqual(y_axis.label, "Cases")
+        self.assertEqual(y_axis.type.value, "linear")
+
+    def test_line_distribution_with_age_split_uses_metric_and_cases_axes(self) -> None:
+        plan_chart = ChartSpec(
+            chart_type="LINE",
+            metrics=[MetricSpec(metric="DTN")],
+        )
+        dimensions = [Dimension(GroupByAge(buckets=[]))]
+        series = [
+            ChartSeries(
+                name="30-39",
+                data=[
+                    ChartPoint(x=30, y=2),
+                    ChartPoint(x=60, y=5),
+                    ChartPoint(x=90, y=1),
+                ],
+            )
+        ]
+
+        chart = build_chart_dto(
+            plan_chart=plan_chart,
+            dimensions=dimensions,
+            series=series,
+            derived_axes=None,
+        )
+
+        self.assertIsNotNone(chart.metadata.x_axis)
+        self.assertIsNotNone(chart.metadata.y_axis)
+        x_axis = chart.metadata.x_axis
+        y_axis = chart.metadata.y_axis
+        if x_axis is None or y_axis is None:
+            self.fail("Expected both axes to be present")
+        self.assertEqual(x_axis.label, "door to needle (minutes)")
         self.assertEqual(x_axis.type.value, "linear")
         self.assertEqual(y_axis.label, "Cases")
         self.assertEqual(y_axis.type.value, "linear")

--- a/tests/test_origin_scope_resolver_semantics.py
+++ b/tests/test_origin_scope_resolver_semantics.py
@@ -90,6 +90,79 @@ class OriginScopeResolverSemanticsTests(unittest.TestCase):
         self.assertEqual(len(providers), 1)
         self.assertEqual(providers[0]["id"], 1853)
         self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].get("user"), "user-1")
+
+    def test_resolve_metric_origin_enriches_mine_scope_with_provider_label(self) -> None:
+        metric = S.MetricSpec(
+            metric="DTN",
+            originScope=S.OriginScopeSpec(scopeType="mine"),
+        )
+
+        with patch.object(
+            origin_scope_resolver,
+            "_resolve_scope",
+            return_value=(S.DataOriginSpec(providerId=[1853]), "Army Alhama de Murcia Hospital"),
+        ):
+            resolved = origin_scope_resolver._resolve_metric_origin(
+                metric,
+                default_scope=None,
+                user_sub="user-1",
+                trace_id="trace-3",
+                fail_open_for_default_scope=False,
+                inferred_country_code=None,
+            )
+
+        self.assertIsNotNone(resolved.origin_scope)
+        self.assertEqual(resolved.origin_scope.label, "Army Alhama de Murcia Hospital")
+        self.assertEqual(resolved.data_origin.provider_id, [1853])
+
+    def test_resolve_metric_origin_overwrites_generic_mine_label(self) -> None:
+        for placeholder in ["My hospital", "mine", "My Hospital", "our hospital"]:
+            with self.subTest(placeholder=placeholder):
+                metric = S.MetricSpec(
+                    metric="DTN",
+                    originScope=S.OriginScopeSpec(scopeType="mine", label=placeholder),
+                )
+
+                with patch.object(
+                    origin_scope_resolver,
+                    "_resolve_scope",
+                    return_value=(S.DataOriginSpec(providerId=[279]), "Aalborg University - Hospital"),
+                ):
+                    resolved = origin_scope_resolver._resolve_metric_origin(
+                        metric,
+                        default_scope=None,
+                        user_sub="user-1",
+                        trace_id="trace-4",
+                        fail_open_for_default_scope=False,
+                        inferred_country_code=None,
+                    )
+
+                self.assertEqual(resolved.origin_scope.label, "Aalborg University - Hospital")
+
+    def test_resolve_metric_origin_keeps_scope_label_when_resolver_returns_none(self) -> None:
+        # When _resolve_scope returns no label (non-mine scopes), the original
+        # scope label is preserved unchanged.
+        metric = S.MetricSpec(
+            metric="DTN",
+            originScope=S.OriginScopeSpec(scopeType="provider_name", value="My Clinic", label="My Clinic"),
+        )
+
+        with patch.object(
+            origin_scope_resolver,
+            "_resolve_scope",
+            return_value=(S.DataOriginSpec(providerId=[279]), None),
+        ):
+            resolved = origin_scope_resolver._resolve_metric_origin(
+                metric,
+                default_scope=None,
+                user_sub="user-1",
+                trace_id="trace-5",
+                fail_open_for_default_scope=False,
+                inferred_country_code=None,
+            )
+
+        self.assertEqual(resolved.origin_scope.label, "My Clinic")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the codebase, focusing on more accurate handling and propagation of scope labels (especially for "mine" scopes), enhanced error logging for GraphQL responses, and minor code cleanups. The most important changes are summarized below.

### Scope Label Handling and Propagation

* The logic for resolving a user's default scope (`mine`) now extracts and propagates a `label` (e.g., the hospital name) from provider or group data, making this label available throughout the planning and metric resolution process. This allows for more accurate and dynamic labeling instead of always using a static label like "My Hospital". [[1]](diffhunk://#diff-d4c9582681e16dcaaadff110c9ca1608893c82d9c189adaa84bc7ddd59806242R92) [[2]](diffhunk://#diff-d4c9582681e16dcaaadff110c9ca1608893c82d9c189adaa84bc7ddd59806242L632-R651) [[3]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL551-R564) [[4]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL837-R832) [[5]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL848-R873) [[6]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL948-R943) [[7]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aR967) [[8]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aR986-R998)
* The `_metric_scope_label` function no longer returns a hardcoded "My Hospital" label for "mine" scopes, relying instead on the propagated label.
* Example files were updated to remove the static "My hospital" label in `origin_scope`. [[1]](diffhunk://#diff-224b9045e45ffab0dcbd18fb613eca54094630616cdf0108d5a992f72771d968L56) [[2]](diffhunk://#diff-e76fe46674b1f66fa27bf298c63ec57b54c28fdb7e8a4d75958e952b1f38ffc3L63)

### GraphQL Error Logging Improvements

* Added a utility function `_summarize_graphql_errors` that aggregates GraphQL error messages, codes, and paths, and includes a sample of errors. This summary is now included in error logs, providing richer diagnostics for backend GraphQL errors. [[1]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075R6) [[2]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075R20-R60) [[3]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075L168-R228)
* Error and warning messages referencing GraphQL errors now consistently use the phrase "GraphQL errors" instead of "validation errors". [[1]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075L249-R293) [[2]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075L281-R325)

### Minor Refactorings and Cleanups

* Simplified multi-line assignments for environment variable parsing and cache TTL configuration for improved readability. [[1]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL28-R28) [[2]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL40-R38)
* Minor code formatting improvements for error handling and validation logic. [[1]](diffhunk://#diff-a0c8968f38392e328447a0b0054d279c70164e3c8c4968504f85aeb3efcee15aL408-R405) [[2]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075L210-R260) [[3]](diffhunk://#diff-54e07fc82ec4ba2a8e6384c35927442eede90ca77c6cb1f85bc61936f6582075L232-R279)
* Added the `user` parameter when calling the analytics center client for provider search, aligning with expected API parameters.
* Commented out unused logic in chart builder regarding distribution axes and dimensions.