### PR TITLE
Fix orchestrator timeouts, cross-turn context leaks, and entity extraction bugs found via CVaLab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ orjson==3.11.6
 packaging==25.0
 pandas==2.2.3
 pandas-stubs==2.3.0.250703
-pluggy==1.0.0
+pluggy==1.6.0
 prompt-toolkit==3.0.28
 propcache==0.3.2
 pydantic==2.10.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,8 @@ pydantic==2.10.6
 pydantic-settings==2.10.1
 pydantic_core==2.27.2
 Pygments==2.20.0
+pytest==8.4.2
+pytest-asyncio==0.24.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 pytz==2025.2
@@ -100,6 +102,7 @@ tzdata==2025.2
 ujson==5.13.0
 urllib3==2.7.0
 uvloop==0.17.0
+watchdog==6.0.0
 wcwidth==0.2.6
 yarl==1.20.1
 zstandard==0.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==22.1.0
 aiohappyeyeballs==2.6.1
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.9.0
@@ -62,8 +62,8 @@ pydantic==2.10.6
 pydantic-settings==2.10.1
 pydantic_core==2.27.2
 Pygments==2.20.0
-pytest==8.4.2
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==1.4.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 pytz==2025.2

--- a/src/actions/actions/visualization_action.py
+++ b/src/actions/actions/visualization_action.py
@@ -347,26 +347,21 @@ _LATEST_ENTITY_PRECEDENCE_KEYS = {
     "date",
 }
 
-# Subset of _LATEST_ENTITY_PRECEDENCE_KEYS that identify *this specific request's*
-# comparison target rather than sticky session state (e.g. a date range, which
-# should keep applying to follow-up turns that don't restate it). If the latest
-# turn doesn't mention one of these, any value inherited from earlier turns in the
-# thread must be dropped rather than silently carried forward -- otherwise a
-# hospital named in an earlier Mann-Whitney comparison leaks into an unrelated
-# follow-up chart request that names no hospital at all.
-_LATEST_ENTITY_CLEAR_ON_ABSENCE_KEYS = {
-    "hospital_name",
-    "hospital_scope_reference",
-    "country_code",
-    "group_id",
-}
-
 
 def merge_latest_with_thread_entities(
     latest_entities: Dict[str, Any],
     events: List[Dict[str, Any]],
     fallback_limit: int = 12,
 ) -> Dict[str, Any]:
+    """Merge the current turn's entities with the anchored visualization
+    thread's entities. Only called when the caller has already decided the
+    thread should carry forward at all (see
+    _should_carry_forward_visualization_context) -- a fresh, unrelated
+    generate_visualization request skips this entirely rather than being
+    merged and then selectively un-merged, so there's nothing here to guard
+    against a stale identity entity (hospital, country, ...) leaking into an
+    unrelated request.
+    """
     thread_entities = _collect_visualization_thread_entities(events, fallback_limit=fallback_limit)
     if not thread_entities:
         return dict(latest_entities)
@@ -376,15 +371,62 @@ def merge_latest_with_thread_entities(
         if isinstance(value, list):
             merged[key] = _dedupe_list_values(cast(List[Any], value))
 
-    # For cohort/statistical keys, the latest user turn must be authoritative: it
-    # overrides an inherited thread value outright, and for scope-identity keys
-    # (not sticky filters like date) its absence clears any inherited value too.
+    # A restated identity/cohort key in the latest turn is authoritative: it
+    # replaces (not appends to) whatever was inherited from earlier turns.
     for key in _LATEST_ENTITY_PRECEDENCE_KEYS:
         if key in latest_entities:
             merged[key] = latest_entities[key]
-        elif key in _LATEST_ENTITY_CLEAR_ON_ABSENCE_KEYS:
-            merged.pop(key, None)
     return merged
+
+
+def _is_awaiting_clarification_reply(events: List[Dict[str, Any]]) -> bool:
+    """Whether the bot's most recent utterance before the current turn was a
+    clarification request -- i.e. this turn completes that pending ask rather
+    than starting a fresh one.
+
+    Deliberately derived from events rather than the
+    awaiting_visualization_clarification slot: action_clarify_visualization_request
+    flips that slot to False as part of its own return events (before its
+    FollowupAction, action_oneshot_generate_visualization, re-derives this same
+    context later in the same turn), so the slot can't be read consistently by
+    both. The events are stable across both reads.
+    """
+    last_user_idx = -1
+    for idx in range(len(events) - 1, -1, -1):
+        if events[idx].get("event") == "user":
+            last_user_idx = idx
+            break
+    if last_user_idx < 0:
+        return False
+
+    for idx in range(last_user_idx - 1, -1, -1):
+        ev = events[idx]
+        if ev.get("event") != "bot":
+            continue
+        payload = _extract_bot_custom_payload(ev)
+        if payload and payload.get("type") == "visualization_query_decision":
+            return payload.get("decision") == "clarify"
+    return False
+
+
+def _should_carry_forward_visualization_context(intent_name: str, events: List[Dict[str, Any]]) -> bool:
+    """Whether this turn should inherit entities/history from earlier turns
+    in the visualization thread at all.
+
+    A fresh generate_visualization request starts clean: no entities, no
+    conversation history from earlier turns, full stop -- it's a new ask, not
+    a continuation. update_visualization explicitly means "modify the
+    existing plan", so it carries the thread forward by design. A reply while
+    the bot is awaiting clarification is completing the request that's
+    already anchored, not replacing it, so it also carries forward.
+    clarify_visualization carries forward even outside that state: per
+    rules/visualization.yml, its NLU training data is terse follow-on
+    instructions like "group by X" or "filter by Y", which only make sense as
+    a modification of the current chart, never as a standalone request.
+    """
+    if intent_name in ("update_visualization", "clarify_visualization"):
+        return True
+    return _is_awaiting_clarification_reply(events)
 
 
 def _extract_bot_custom_payload(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -519,14 +561,20 @@ class ActionClarifyVisualizationRequest(Action):  # pyright: ignore
                 language = resolve_language(metadata=metadata, slots=slots, tracker=tracker)
 
                 events = tracker.events
-                extracted_entities = canonicalize_ssot_entities(
-                    merge_latest_with_thread_entities(
-                        canonicalize_ssot_entities(extract_entities_from_latest_message(latest_msg)),
-                        events,
-                        fallback_limit=fallback_limit,
+                intent_name = _extract_intent_name_from_user_event(latest_msg)
+                carry_forward = _should_carry_forward_visualization_context(intent_name, events)
+                latest_entities = canonicalize_ssot_entities(extract_entities_from_latest_message(latest_msg))
+                if carry_forward:
+                    extracted_entities = canonicalize_ssot_entities(
+                        merge_latest_with_thread_entities(latest_entities, events, fallback_limit=fallback_limit)
                     )
-                )
-                conversation_history = _collect_visualization_thread_messages(events, fallback_limit=fallback_limit)
+                    conversation_history = _collect_visualization_thread_messages(events, fallback_limit=fallback_limit)
+                else:
+                    # Fresh generate_visualization request, not completing a pending
+                    # clarification: start clean, no entities or history from earlier
+                    # turns (see _should_carry_forward_visualization_context).
+                    extracted_entities = latest_entities
+                    conversation_history = []
                 # The current turn's own text is the question; prior turns are carried
                 # via extracted_entities (structured) and conversation_history (passed
                 # separately to the orchestrator's own history field), not by joining
@@ -534,9 +582,7 @@ class ActionClarifyVisualizationRequest(Action):  # pyright: ignore
                 # blending unrelated requests together.
                 planner_question = user_message
 
-                intent_name = _extract_intent_name_from_user_event(latest_msg)
-                is_update = intent_name == "update_visualization"
-                if is_update:
+                if carry_forward:
                     latest_plan_summary = _collect_latest_visualization_plan_summary(events)
                     if latest_plan_summary:
                         planner_question = f"{latest_plan_summary}\n\nUser's newest instruction:\n{planner_question}".strip()
@@ -596,7 +642,7 @@ class ActionClarifyVisualizationRequest(Action):  # pyright: ignore
                         timeout_seconds=_EXECUTE_PLAN_TIMEOUT_SECONDS,
                     ),
                 )
-                ctx.say(
+                dispatcher.utter_message(
                     json_message={
                         "type": "visualization_error",
                         "trace_id": trace_id,
@@ -606,44 +652,7 @@ class ActionClarifyVisualizationRequest(Action):  # pyright: ignore
                         "retry": True,
                     }
                 )
-                ctx.say(
-                    text=translate(
-                        "action.common.error_with_context",
-                        language=language,
-                        params={
-                            "message": timeout_message,
-                            "code": "EXEC_TIMEOUT",
-                            "trace_id": trace_id,
-                        },
-                    )
-                )
-                return None
-            except asyncio.TimeoutError:
-                timeout_message = (
-                    "The visualization execution took too long and timed out. "
-                    "Please try again, narrow the scope, or shorten the date range."
-                )
-                logger.warning(
-                    "Visualization execution timed out",
-                    extra=_action_log_context(
-                        trace_id=trace_id,
-                        action_name=self.name(),
-                        event="actions.visualization.work.timeout",
-                        outcome="failure",
-                        timeout_seconds=_EXECUTE_PLAN_TIMEOUT_SECONDS,
-                    ),
-                )
-                ctx.say(
-                    json_message={
-                        "type": "visualization_error",
-                        "trace_id": trace_id,
-                        "error_code": "EXEC_TIMEOUT",
-                        "reason": "timeout",
-                        "message": timeout_message,
-                        "retry": True,
-                    }
-                )
-                ctx.say(
+                dispatcher.utter_message(
                     text=translate(
                         "action.common.error_with_context",
                         language=language,
@@ -703,13 +712,24 @@ def _extract_request_context(ctx: LongActionContext) -> Dict[str, Any]:
     latest_meta = ctx.metadata
     latest_any = ctx.tracker_snapshot.get("latest_message")
     latest_msg = cast(Dict[str, Any], latest_any) if isinstance(latest_any, dict) else {}
-    extracted_entities = canonicalize_ssot_entities(extract_entities_from_latest_message(latest_msg))
     override_language = resolve_override_language(latest_meta, ctx.slots)
     language = resolve_language(metadata=latest_meta, slots=ctx.slots)
     events = ctx.events
-    extracted_entities = canonicalize_ssot_entities(merge_latest_with_thread_entities(extracted_entities, events, fallback_limit=12))
-    conversation_history = _collect_visualization_thread_messages(events, fallback_limit=12)
-    latest_plan_summary = _collect_latest_visualization_plan_summary(events)
+
+    intent_name = _extract_intent_name_from_user_event(latest_msg)
+    carry_forward = _should_carry_forward_visualization_context(intent_name, events)
+    latest_entities = canonicalize_ssot_entities(extract_entities_from_latest_message(latest_msg))
+    if carry_forward:
+        extracted_entities = canonicalize_ssot_entities(merge_latest_with_thread_entities(latest_entities, events, fallback_limit=12))
+        conversation_history = _collect_visualization_thread_messages(events, fallback_limit=12)
+        latest_plan_summary = _collect_latest_visualization_plan_summary(events)
+    else:
+        # Fresh generate_visualization request, not completing a pending
+        # clarification: start clean, no entities or history from earlier
+        # turns (see _should_carry_forward_visualization_context).
+        extracted_entities = latest_entities
+        conversation_history = []
+        latest_plan_summary = None
 
     # ctx.text is the current turn's own text; prior turns are carried via
     # extracted_entities (structured) and conversation_history (passed separately to
@@ -717,12 +737,7 @@ def _extract_request_context(ctx: LongActionContext) -> Dict[str, Any]:
     # previously confused the planner into blending unrelated requests together.
     planner_question = ctx.text
 
-    latest_any = ctx.tracker_snapshot.get("latest_message")
-    latest_msg_for_intent = cast(Dict[str, Any], latest_any) if isinstance(latest_any, dict) else {}
-    intent_name = _extract_intent_name_from_user_event(latest_msg_for_intent)
-    is_update = intent_name == "update_visualization"
-
-    if latest_plan_summary and is_update:
+    if latest_plan_summary:
         planner_question = f"{latest_plan_summary}\n\nUser's newest instruction:\n{planner_question}".strip()
 
     return {

--- a/src/actions/helpers/visualization.py
+++ b/src/actions/helpers/visualization.py
@@ -128,6 +128,36 @@ def extract_entities_from_latest_message(
         return {}
 
     entities_list = cast(List[Any], entities_any)
+
+    # RegexEntityExtractor's SSOT-derived lookup tables match a literal word
+    # anywhere it appears (e.g. "age" is a valid metric name AND a valid
+    # group_by value), with zero regard for context. DIETClassifier, by
+    # contrast, assigns at most one contextual label per token span. When the
+    # two disagree about what the *same span* of text means (e.g. "age" in
+    # "...grouped by age in 10-year buckets" is unambiguously the group_by,
+    # but the metric lookup table also matches it), the regex-only reading is
+    # a false positive, not a genuine second candidate -- it previously read
+    # to the decision-stage LLM as a real ambiguity ("DTN or AGE?") for an
+    # unambiguous request. Build the set of DIET-confirmed spans first so the
+    # second pass can drop any entity type whose only support is a lookup-table
+    # match contradicted by DIET's own reading of those exact tokens.
+    diet_span_labels: Dict[tuple[Any, Any], str] = {}
+    for ent_any in entities_list:
+        if not isinstance(ent_any, dict):
+            continue
+        ent = cast(Dict[str, Any], ent_any)
+        extractors = ent.get("extractors")
+        extractor_names = (
+            {e.get("extractor") for e in extractors if isinstance(e, dict)}
+            if isinstance(extractors, list)
+            else set()
+        )
+        if "DIETClassifier" in extractor_names:
+            span = (ent.get("start"), ent.get("end"))
+            entity_type = ent.get("entity")
+            if isinstance(entity_type, str):
+                diet_span_labels[span] = entity_type
+
     extracted: Dict[str, Any] = {}
     for ent_any in entities_list:
         if not isinstance(ent_any, dict):
@@ -135,6 +165,21 @@ def extract_entities_from_latest_message(
         ent = cast(Dict[str, Any], ent_any)
         key_any = ent.get("entity")
         if not isinstance(key_any, str) or "value" not in ent:
+            continue
+
+        extractors = ent.get("extractors")
+        extractor_names = (
+            {e.get("extractor") for e in extractors if isinstance(e, dict)}
+            if isinstance(extractors, list)
+            else set()
+        )
+        span = (ent.get("start"), ent.get("end"))
+        diet_label_for_span = diet_span_labels.get(span)
+        if (
+            "DIETClassifier" not in extractor_names
+            and diet_label_for_span is not None
+            and diet_label_for_span != key_any
+        ):
             continue
 
         value = ent["value"]
@@ -145,9 +190,17 @@ def extract_entities_from_latest_message(
         existing = extracted[key_any]
         if isinstance(existing, list):
             existing_list = cast(List[Any], existing)
-            existing_list.append(value)
-        else:
+            if value not in existing_list:
+                existing_list.append(value)
+        elif value != existing:
             extracted[key_any] = [existing, value]
+        # else: identical repeat of an already-captured scalar value (e.g.
+        # "male patients DTN" and "female patients DTN" both mention DTN) --
+        # not a second distinct answer, so it must not turn a clean scalar
+        # into a redundant [DTN, DTN] list. That shape previously read to the
+        # decision-stage LLM as two different metric candidates to choose
+        # between, producing a spurious "which metric?" clarification for an
+        # unambiguous request.
 
     return extracted
 

--- a/src/domain/langchain/schema.py
+++ b/src/domain/langchain/schema.py
@@ -283,6 +283,29 @@ FilterNode = Union[
 ]
 
 
+def _normalize_filter_node(value: Any) -> Any:
+    """Accept a bare JSON list of filters as an equivalent, unambiguous
+    alternate encoding of a single FilterNode.
+
+    The planner LLM sometimes emits "filters": [{"type": "SexFilter", ...}]
+    instead of wrapping multiple filters in an explicit AndFilter (or just
+    the bare object for a single filter) -- a reasonable, lossless way to
+    write "these filters" that FilterNode's schema doesn't accept as-is,
+    which previously caused a validation error (and downstream "I need a bit
+    more detail" clarify) for a plan the LLM had already correctly decided.
+    This reshapes the same, unmodified filter content into the schema's
+    canonical envelope; it never invents or drops a filter the LLM specified.
+    """
+    if not isinstance(value, list):
+        return value
+    items = cast(List[Any], value)
+    if not items:
+        return None
+    if len(items) == 1:
+        return items[0]
+    return {"type": "AndFilter", "and_": items}
+
+
 class GroupBySex(HashableBaseModel):
     """
     Grouping by patient sex.
@@ -861,6 +884,10 @@ class ChartSpec(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
+    @field_validator("filters", mode="before")
+    def normalize_filters(cls, v: Any) -> Any:
+        return _normalize_filter_node(v)
+
     @field_validator("chart_type")
     def validate_chart_type(cls, v: str) -> str:
         v_norm = v.upper()
@@ -890,6 +917,10 @@ class StatisticalTestSpec(BaseModel):
     metrics: List[MetricSpec]
     group_by: Optional[List[GroupBySpec]] = None
     filters: Optional[FilterNode] = None
+
+    @field_validator("filters", mode="before")
+    def normalize_filters(cls, v: Any) -> Any:
+        return _normalize_filter_node(v)
 
     @field_validator("test_type")
     def validate_test_type(cls, v: str) -> str:

--- a/src/executors/mapping/series_mapper.py
+++ b/src/executors/mapping/series_mapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import calendar
 from datetime import datetime
 from typing import Any, Dict, List, Optional, cast
 
@@ -18,6 +19,62 @@ def _metric_code_from_alias(metric_alias: str) -> str:
 
 def metric_label_from_alias(metric_alias: str) -> str:
     return get_metric_display_name(_metric_code_from_alias(metric_alias))
+
+
+def _is_calendar_month(start_dt: datetime, end_dt: datetime) -> bool:
+    if start_dt.year != end_dt.year or start_dt.month != end_dt.month or start_dt.day != 1:
+        return False
+    return end_dt.day == calendar.monthrange(start_dt.year, start_dt.month)[1]
+
+
+def _is_calendar_quarter(start_dt: datetime, end_dt: datetime) -> bool:
+    if start_dt.day != 1 or start_dt.month not in (1, 4, 7, 10):
+        return False
+    last_month = start_dt.month + 2
+    if end_dt.year != start_dt.year or end_dt.month != last_month:
+        return False
+    return end_dt.day == calendar.monthrange(end_dt.year, last_month)[1]
+
+
+def _is_calendar_year(start_dt: datetime, end_dt: datetime) -> bool:
+    return (start_dt.month, start_dt.day) == (1, 1) and (end_dt.year, end_dt.month, end_dt.day) == (start_dt.year, 12, 31)
+
+
+def _grouped_time_period_label(tp_start: str, tp_end: Optional[str]) -> str:
+    """Label for one bucket of a grouped/time-series chart.
+
+    Previously hardcoded to "%Y-%m" for every bucket regardless of its real
+    span, which collapsed e.g. 30 distinct single-day buckets onto 1-2 month
+    labels -- a "last 30 days, daily" line chart rendered as if it had ~2
+    data points instead of 30. A bucket that's a genuine, calendar-aligned
+    month/quarter/year (start/end fall exactly on that period's boundaries)
+    still gets the clean "%Y-%m" / "%Y-Qn" / "%Y" label those grains are
+    meant to show; anything else (a single day, a week, or any other
+    non-calendar-aligned span) gets full date precision so distinct buckets
+    can never share a label.
+    """
+    try:
+        start_dt = datetime.fromisoformat(tp_start)
+    except ValueError as exc:
+        raise ValueError(f"Invalid ISO date in grouped time period label: {tp_start!r}") from exc
+
+    end_dt: Optional[datetime] = None
+    if tp_end:
+        try:
+            end_dt = datetime.fromisoformat(tp_end)
+        except ValueError as exc:
+            raise ValueError(f"Invalid ISO date in grouped time period label: {tp_end!r}") from exc
+
+    if end_dt is not None:
+        if _is_calendar_year(start_dt, end_dt):
+            return start_dt.strftime("%Y")
+        if _is_calendar_quarter(start_dt, end_dt):
+            quarter = (start_dt.month - 1) // 3 + 1
+            return f"{start_dt.year}-Q{quarter}"
+        if _is_calendar_month(start_dt, end_dt):
+            return start_dt.strftime("%Y-%m")
+
+    return start_dt.strftime("%Y-%m-%d")
 
 
 def period_to_label(tp: TimePeriod) -> str:
@@ -110,13 +167,7 @@ def map_metrics_payload_to_series(
                         tp_end = getattr(tp, "endDate", None) or getattr(tp, "end_date", None)
 
                 if add_time_period_labels and tp_start:
-                    try:
-                        dt = datetime.fromisoformat(str(tp_start))
-                        x_value = dt.strftime("%Y-%m")
-                    except ValueError as exc:
-                        raise ValueError(
-                            f"Invalid ISO date in grouped time period label: {tp_start!r}"
-                        ) from exc
+                    x_value = _grouped_time_period_label(str(tp_start), str(tp_end) if tp_end else None)
                 elif server_label:
                     mapped = get_enum_option_label(group_by_field, server_label) if group_by_field else None
                     x_value = mapped or server_label

--- a/src/planners/langchain/fewshot_examples/dtn_bar_explicit_date_range.json
+++ b/src/planners/langchain/fewshot_examples/dtn_bar_explicit_date_range.json
@@ -1,6 +1,6 @@
 {
   "category": "filters",
-  "user_utterance": "Show me a bar chart of DTN for patients in 2026",
+  "user_utterance": "Create a bar chart for DTN from 2023-01-01 to 2023-12-31",
   "entities_detected": {
     "metric": [
       "DTN"
@@ -9,7 +9,8 @@
       "BAR"
     ],
     "date": [
-      "2026"
+      "2023-01-01",
+      "2023-12-31"
     ]
   },
   "assistant": {
@@ -23,7 +24,14 @@
             "percentile": null
           },
           "splits": null,
-          "time": null,
+          "time": {
+            "grain": null,
+            "window": {
+              "start_date": "2023-01-01",
+              "end_date": "2023-12-31"
+            },
+            "include_partial": null
+          },
           "x_axis": {
             "role": "METRIC_VALUE",
             "metric": "DTN",
@@ -41,21 +49,7 @@
             "grain": null
           }
         },
-        "filters": {
-          "type": "AndFilter",
-          "and_": [
-            {
-              "operator": "GE",
-              "type": "DateFilter",
-              "value": "2026-01-01"
-            },
-            {
-              "operator": "LE",
-              "type": "DateFilter",
-              "value": "2026-12-31"
-            }
-          ]
-        },
+        "filters": null,
         "metrics": [
           {
             "metric": "DTN",

--- a/src/planners/langchain/fewshot_examples/dtn_bare_country_scope.json
+++ b/src/planners/langchain/fewshot_examples/dtn_bare_country_scope.json
@@ -1,21 +1,18 @@
 {
-  "category": "filters",
-  "user_utterance": "Show me a bar chart of DTN for patients in 2026",
+  "category": "cross_hospital",
+  "user_utterance": "show dtn from Czech Republic",
   "entities_detected": {
     "metric": [
       "DTN"
     ],
-    "chart_type": [
-      "BAR"
-    ],
-    "date": [
-      "2026"
+    "country_code": [
+      "CZ"
     ]
   },
   "assistant": {
     "charts": [
       {
-        "chart_type": "BAR",
+        "chart_type": "LINE",
         "semantics": {
           "intent": "DISTRIBUTION",
           "measure": {
@@ -41,26 +38,17 @@
             "grain": null
           }
         },
-        "filters": {
-          "type": "AndFilter",
-          "and_": [
-            {
-              "operator": "GE",
-              "type": "DateFilter",
-              "value": "2026-01-01"
-            },
-            {
-              "operator": "LE",
-              "type": "DateFilter",
-              "value": "2026-12-31"
-            }
-          ]
-        },
+        "filters": null,
         "metrics": [
           {
             "metric": "DTN",
             "data_origin": null,
-            "origin_scope": null
+            "origin_scope": {
+              "scope_type": "country_code",
+              "value": "CZ",
+              "label": "Czech Republic",
+              "country_code": "CZ"
+            }
           }
         ],
         "numeric_resolution": null

--- a/src/planners/langchain/fewshot_examples/dtn_ignore_spurious_country_from_date_range.json
+++ b/src/planners/langchain/fewshot_examples/dtn_ignore_spurious_country_from_date_range.json
@@ -1,43 +1,51 @@
 {
   "category": "filters",
-  "user_utterance": "Show me a bar chart of DTN for patients in 2026",
+  "user_utterance": "show dtn trend from 2023 to 2026",
   "entities_detected": {
     "metric": [
       "DTN"
     ],
     "chart_type": [
-      "BAR"
+      "LINE"
     ],
     "date": [
+      "2023",
       "2026"
+    ],
+    "country_code": [
+      "TO"
     ]
   },
   "assistant": {
     "charts": [
       {
-        "chart_type": "BAR",
+        "chart_type": "LINE",
         "semantics": {
-          "intent": "DISTRIBUTION",
+          "intent": "TREND",
           "measure": {
-            "type": "DISTRIBUTION",
+            "type": "MEAN",
             "percentile": null
           },
           "splits": null,
-          "time": null,
-          "x_axis": {
-            "role": "METRIC_VALUE",
-            "metric": "DTN",
-            "label": null,
-            "unit": null,
-            "aggregation": null,
-            "grain": null
+          "time": {
+            "grain": "QUARTER",
+            "window": null,
+            "include_partial": null
           },
-          "y_axis": {
-            "role": "COUNT",
+          "x_axis": {
+            "role": "TIME",
             "metric": null,
             "label": null,
             "unit": null,
             "aggregation": null,
+            "grain": "QUARTER"
+          },
+          "y_axis": {
+            "role": "AGGREGATE_VALUE",
+            "metric": "DTN",
+            "label": null,
+            "unit": null,
+            "aggregation": "MEAN",
             "grain": null
           }
         },
@@ -47,7 +55,7 @@
             {
               "operator": "GE",
               "type": "DateFilter",
-              "value": "2026-01-01"
+              "value": "2023-01-01"
             },
             {
               "operator": "LE",

--- a/src/planners/langchain/fewshot_examples/dtn_ignore_spurious_group_by_from_time_window.json
+++ b/src/planners/langchain/fewshot_examples/dtn_ignore_spurious_group_by_from_time_window.json
@@ -1,0 +1,67 @@
+{
+  "category": "filters",
+  "user_utterance": "Show me DTN over the last year",
+  "entities_detected": {
+    "metric": [
+      "DTN"
+    ],
+    "chart_type": [
+      "LINE"
+    ],
+    "time_window": [
+      "LAST_YEAR"
+    ],
+    "group_by": [
+      "YEAR"
+    ]
+  },
+  "assistant": {
+    "charts": [
+      {
+        "chart_type": "LINE",
+        "semantics": {
+          "intent": "TREND",
+          "measure": {
+            "type": "MEAN",
+            "percentile": null
+          },
+          "splits": null,
+          "time": {
+            "grain": "MONTH",
+            "window": {
+              "last_n": 1,
+              "unit": "YEAR"
+            },
+            "include_partial": null
+          },
+          "x_axis": {
+            "role": "TIME",
+            "metric": null,
+            "label": null,
+            "unit": null,
+            "aggregation": null,
+            "grain": "MONTH"
+          },
+          "y_axis": {
+            "role": "AGGREGATE_VALUE",
+            "metric": "DTN",
+            "label": null,
+            "unit": null,
+            "aggregation": "MEAN",
+            "grain": null
+          }
+        },
+        "filters": null,
+        "metrics": [
+          {
+            "metric": "DTN",
+            "data_origin": null,
+            "origin_scope": null
+          }
+        ],
+        "numeric_resolution": null
+      }
+    ],
+    "statistical_tests": null
+  }
+}

--- a/src/planners/langchain/fewshot_examples/dtn_line_year_to_year_range.json
+++ b/src/planners/langchain/fewshot_examples/dtn_line_year_to_year_range.json
@@ -1,43 +1,57 @@
 {
   "category": "filters",
-  "user_utterance": "Show me a bar chart of DTN for patients in 2026",
+  "user_utterance": "Make a line graph for dtn for male ischemic patients from 2025 to 2026",
   "entities_detected": {
     "metric": [
       "DTN"
     ],
     "chart_type": [
-      "BAR"
+      "LINE"
+    ],
+    "sex": [
+      "MALE"
+    ],
+    "stroke_type": [
+      "ISCHEMIC"
     ],
     "date": [
+      "2025",
       "2026"
     ]
   },
   "assistant": {
     "charts": [
       {
-        "chart_type": "BAR",
+        "chart_type": "LINE",
         "semantics": {
-          "intent": "DISTRIBUTION",
+          "intent": "TREND",
           "measure": {
-            "type": "DISTRIBUTION",
+            "type": "MEAN",
             "percentile": null
           },
           "splits": null,
-          "time": null,
-          "x_axis": {
-            "role": "METRIC_VALUE",
-            "metric": "DTN",
-            "label": null,
-            "unit": null,
-            "aggregation": null,
-            "grain": null
+          "time": {
+            "grain": "QUARTER",
+            "window": {
+              "start_date": "2025-01-01",
+              "end_date": "2026-12-31"
+            },
+            "include_partial": null
           },
-          "y_axis": {
-            "role": "COUNT",
+          "x_axis": {
+            "role": "TIME",
             "metric": null,
             "label": null,
             "unit": null,
             "aggregation": null,
+            "grain": "QUARTER"
+          },
+          "y_axis": {
+            "role": "AGGREGATE_VALUE",
+            "metric": "DTN",
+            "label": null,
+            "unit": null,
+            "aggregation": "MEAN",
             "grain": null
           }
         },
@@ -45,14 +59,12 @@
           "type": "AndFilter",
           "and_": [
             {
-              "operator": "GE",
-              "type": "DateFilter",
-              "value": "2026-01-01"
+              "type": "StrokeFilter",
+              "value": "ISCHEMIC"
             },
             {
-              "operator": "LE",
-              "type": "DateFilter",
-              "value": "2026-12-31"
+              "type": "SexFilter",
+              "value": "MALE"
             }
           ]
         },

--- a/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_country_average.json
+++ b/src/planners/langchain/fewshot_examples/dtn_my_hospital_vs_country_average.json
@@ -12,7 +12,7 @@
       "mine",
       "country_average"
     ],
-    "country": [
+    "country_code": [
       "IT"
     ]
   },

--- a/src/planners/langchain/pipeline.py
+++ b/src/planners/langchain/pipeline.py
@@ -34,6 +34,7 @@ from src.util.logging_utils import bind_current_context, log_context
 logger = logging.getLogger(__name__)
 _ENABLE_DYNAMIC_FEW_SHOTS = True
 _ENABLE_PLAN_CACHE = True
+_ENABLE_PLAN_CRITIQUE = True
 
 _FEWSHOT_TOKEN_WEIGHT = 1.0
 _FEWSHOT_ENTITY_KEY_WEIGHT = 6.0
@@ -65,7 +66,16 @@ _INTENT_KEYWORDS: Dict[str, List[str]] = {
 
 _SUPPORTED_STAT_TESTS = ["MANN_WHITNEY_U_TEST"]
 
-_PLANNER_REQUEST_TIMEOUT_SECONDS = 30.0
+# 30s was tighter than observed real-world LLM latency for this call (plan
+# generation and, since the critique pass, plan critique too both routinely
+# take 20-45s), causing a per-attempt PlannerTimeoutError on otherwise-normal
+# requests. Env-configurable to match its sibling timeouts in
+# request_orchestrator.py rather than requiring a code change to retune.
+_PLANNER_REQUEST_TIMEOUT_RAW = env.get_env("ACTIONS_LLM_PLANNER_REQUEST_TIMEOUT_SECONDS", default="") or ""
+try:
+    _PLANNER_REQUEST_TIMEOUT_SECONDS = max(1.0, float(_PLANNER_REQUEST_TIMEOUT_RAW))
+except Exception:
+    _PLANNER_REQUEST_TIMEOUT_SECONDS = 45.0
 _MAX_FEW_SHOTS = 3
 _PLAN_CACHE_SIZE = 256
 _PLAN_CACHE_TTL_SECONDS = 900.0
@@ -149,6 +159,52 @@ def _assert_required_semantics(plan: AnalysisPlan) -> None:
         if chart.semantics.measure is None:
             raise ValueError(
                 f"Invalid AnalysisPlan: charts[{idx}].semantics.measure is required"
+            )
+
+
+def _collect_date_filter_bounds(node: Any) -> List[tuple[str, str]]:
+    """Recursively collect (operator, value) pairs from DateFilter nodes
+    nested anywhere under `node`, through And/Or/Not combinators."""
+    from src.domain.langchain.schema import AndFilter, DateFilter, NotFilter, OrFilter
+
+    if node is None:
+        return []
+    if isinstance(node, DateFilter):
+        return [(node.operator, node.value)]
+    if isinstance(node, AndFilter):
+        return [pair for child in node.and_ for pair in _collect_date_filter_bounds(child)]
+    if isinstance(node, OrFilter):
+        return [pair for child in node.or_ for pair in _collect_date_filter_bounds(child)]
+    if isinstance(node, NotFilter):
+        return _collect_date_filter_bounds(node.not_)
+    return []
+
+
+def _assert_no_redundant_date_encoding(plan: AnalysisPlan) -> None:
+    """plan_system.txt explicitly instructs the planner to use
+    semantics.time.window (TimeRange) for an explicit absolute date range and
+    NOT also add a redundant DateFilter for that same range -- but this is
+    occasionally violated live (the same bounds encoded both ways). This is a
+    purely mechanical, unambiguous structural rule, so it's enforced
+    deterministically here rather than left to the critique pass's fuzzier,
+    request-faithfulness judgment (which is scoped to whether the plan
+    matches the request, not whether it duplicates itself).
+    """
+    from src.domain.langchain.schema import TimeRange
+
+    for idx, chart in enumerate(plan.charts or []):
+        window = chart.semantics.time.window if chart.semantics and chart.semantics.time else None
+        if not isinstance(window, TimeRange):
+            continue
+        bounds = _collect_date_filter_bounds(chart.filters)
+        ge_values = {value for op, value in bounds if op == "GE"}
+        le_values = {value for op, value in bounds if op == "LE"}
+        if window.start_date in ge_values and window.end_date in le_values:
+            raise ValueError(
+                f"Invalid AnalysisPlan: charts[{idx}] encodes the same date range twice -- "
+                f"both semantics.time.window (TimeRange {window.start_date} to {window.end_date}) "
+                "and an equivalent DateFilter in filters. Keep only semantics.time.window for this "
+                "range and remove the redundant DateFilter."
             )
 
 
@@ -482,6 +538,55 @@ plan_prompt: ChatPromptTemplate = ChatPromptTemplate.from_messages(  # type: ign
 
 plan_chain: Any = plan_prompt | llm
 
+critic_prompt: ChatPromptTemplate = ChatPromptTemplate.from_messages(  # type: ignore
+    [
+        ("system", load_prompt_text("critic_system")),
+        (
+            "user",
+            "USER_UTTERANCE:\n{question}\n\nENTITIES_DETECTED(JSON):\n{entities}\n\nCANDIDATE_PLAN_JSON:\n{candidate_plan}",
+        ),
+    ]
+)
+
+critic_chain: Any = critic_prompt | llm
+
+
+def _critique_plan(question: str, entities: Dict[str, Any], plan: AnalysisPlan) -> Optional[str]:
+    """Ask an independent LLM pass whether `plan` faithfully implements
+    `question`/`entities`, rather than hand-coding a comparator per failure
+    mode (chart count, date fidelity, dropped update fields, ...). Returns a
+    human-readable issue summary on mismatch, None when the plan checks out.
+
+    This is a holistic judgment call, not a deterministic guarantee -- it
+    complements (does not replace) schema-level validation, which stays
+    fully deterministic. Any exception here is treated as "no complaint"
+    rather than blocking planning on the critic itself being unavailable.
+    """
+    if not _ENABLE_PLAN_CRITIQUE:
+        return None
+    try:
+        raw_result: Any = _invoke_with_timeout(
+            critic_chain,
+            {
+                "question": question,
+                "entities": json.dumps(entities),
+                "candidate_plan": plan.model_dump_json(indent=2),
+            },
+            label="plan_critique",
+        )
+        verdict = json.loads(_extract_json_block(_extract_text(raw_result)))
+    except Exception:
+        logger.exception("[Planner] Plan critique pass failed; proceeding without it")
+        return None
+
+    if not isinstance(verdict, dict) or verdict.get("ok") is True:
+        return None
+
+    issues = verdict.get("issues")
+    if isinstance(issues, list) and issues:
+        return "; ".join(str(issue) for issue in issues)
+    return "Plan does not faithfully match the request."
+
 
 class GeneratePlanDebug(TypedDict):
     """Typed structure for debug output of generate_analysis_plan."""
@@ -616,18 +721,21 @@ def generate_analysis_plan(
             if progress_cb is not None:
                 progress_cb(f"Thinking about a plan (attempt {attempt}/{total_attempts}).")
 
-            raw_result: Any = _invoke_with_timeout(plan_chain, plan_inputs, label=f"plan_chain_attempt_{attempt}")
-            steps.append(
-                {
-                    "step": f"plan_attempt_{attempt}",
-                    "prompt": "(prompt logging disabled)",
-                    "response": raw_result,
-                }
-            )
-
             try:
+                raw_result: Any = _invoke_with_timeout(plan_chain, plan_inputs, label=f"plan_chain_attempt_{attempt}")
+                steps.append(
+                    {
+                        "step": f"plan_attempt_{attempt}",
+                        "prompt": "(prompt logging disabled)",
+                        "response": raw_result,
+                    }
+                )
                 result = _coerce_analysis_plan(raw_result)
                 _assert_required_semantics(result)
+                _assert_no_redundant_date_encoding(result)
+                critique_issues = _critique_plan(question, entities, result)
+                if critique_issues:
+                    raise ValueError(f"Plan does not faithfully match the request: {critique_issues}")
                 break
             except Exception as exc:
                 last_error = exc
@@ -639,8 +747,13 @@ def generate_analysis_plan(
                     }
                 )
                 if attempt >= total_attempts:
+                    logger.warning(
+                        "[Planner] Exhausted retries with an unresolved validation/critique issue; "
+                        "returning last attempt as-is: %s",
+                        exc,
+                    )
                     break
-                plan_inputs["reasoning"] = f"Previous output failed schema validation. Return ONLY a valid AnalysisPlan JSON object. Validation error: {exc}"
+                plan_inputs["reasoning"] = f"Previous output was rejected: {exc}. Return ONLY a corrected, valid AnalysisPlan JSON object."
 
         if result is None:
             raise ValueError(f"Planner failed to produce a valid AnalysisPlan after {total_attempts} attempts") from last_error

--- a/src/planners/langchain/prompts/critic_system.txt
+++ b/src/planners/langchain/prompts/critic_system.txt
@@ -1,0 +1,14 @@
+You are a strict reviewer checking whether a machine-generated AnalysisPlan faithfully implements a user's visualization request. You are NOT re-planning and NOT checking schema validity (that is already guaranteed) -- you are the last line of defense against a plan that is well-formed but silently wrong: it built something plausible instead of what was actually asked for.
+
+Compare USER_UTTERANCE, ENTITIES_DETECTED, and CANDIDATE_PLAN_JSON. Judge whether the plan is a faithful, complete implementation of the request. Pay particular attention to:
+- Explicit counts. If the user asked for a specific number of charts, lines, or series (e.g. "10 line graphs", "three charts"), the plan's chart/series count must match exactly.
+- Explicit dates and date ranges. If the user stated specific dates, years, or a range (e.g. "from 2023 to 2026", "in 2025"), that exact range must be reflected in the relevant chart's filters or semantics.time.window -- not a default window, not a truncated or open-ended range. A bare year or year-to-year phrase means the FULL calendar year(s): "in 2025" is 2025-01-01 to 2025-12-31, and "from 2023 to 2026" is 2023-01-01 to 2026-12-31 inclusive of both endpoints' entire years. That full-year expansion is the correct, expected reading, not something "broader than requested" -- only flag a date mismatch if the plan's bounds fall outside what the stated year(s) or date(s) actually cover, or add a span the user never mentioned at all.
+- Named cohorts/scopes/entities. Every distinct entity the user explicitly named as something they want to see (a specific provider group, hospital, sex, stroke type, age/NIHSS bucket, etc.) must actually appear somewhere in the plan's metrics, filters, or splits -- not silently dropped or merged away.
+- Update/iteration fidelity. If USER_UTTERANCE begins with "Previous chart plan", this is an edit to that existing plan. Everything from the previous plan must be preserved except what the user's newest instruction explicitly asks to change. Flag anything that looks silently dropped (a filter, split, metric, or chart that disappeared without the user asking to remove it).
+- Requested content type. The metric(s), chart type(s), and statistical test(s) in the plan must match what the user actually asked for, not a plausible-sounding substitute.
+
+Do NOT invent complaints about things the user never specified. A missing date range is only a problem if the user actually gave one. Ambiguity the user themselves left unresolved is not a defect in the plan. Only flag a concrete, specific mismatch between what was asked and what the plan contains.
+
+Respond with ONLY a JSON object, no other text:
+- If the plan faithfully matches the request: {{"ok": true}}
+- If it does not: {{"ok": false, "issues": ["short specific description of each mismatch"]}}

--- a/src/planners/langchain/prompts/decision_system.txt
+++ b/src/planners/langchain/prompts/decision_system.txt
@@ -2,12 +2,37 @@ You are the triage stage for a clinical analytics visualization assistant.
 Return strict JSON only:
 {{
   "decision": "proceed" | "clarify" | "reject",
-  "reason": "short_snake_case_reason",
+  "reason": "all_required_fields_present" | "missing_required_fields" | "ambiguous_request" | "out_of_scope" | "invalid_date_format" | "insufficient_information",
   "missing_fields": string[] | null,
   "clarification_type": string | null,
   "clarification_options": string[] | null,
   "message": string | null
 }}
+
+"reason" must always be exactly one of the six values above -- never invent your own
+wording or a synonym of one of them, even if it feels more precise for this specific
+request. Consumers of this response (tests, downstream safeguards) match against
+these exact strings, so a new phrasing is a breaking change, not a nicer label.
+Use them as follows:
+- "all_required_fields_present": decision="proceed". All required fields for the
+  detected intent are present and unambiguous.
+- "missing_required_fields": decision="clarify". Exactly one required field is
+  genuinely absent from ENTITIES_JSON (not just absent from USER_QUESTION's own
+  text -- ENTITIES_JSON is the authoritative, already-resolved set for this
+  request, including anything carried over from earlier turns). Put that field's
+  name in missing_fields.
+- "ambiguous_request": decision="clarify". Required fields are technically present,
+  but something else about the request is unclear enough that you cannot proceed
+  without asking (e.g. multiple equally-plausible metrics, contradictory filters).
+- "out_of_scope": decision="reject". The request is not a visualization/analytics
+  request at all -- unrelated to clinical stroke-care analytics entirely. Never use
+  this reason merely because a field is missing or a chart type is unspecified;
+  those are "missing_required_fields", not "out_of_scope".
+- "invalid_date_format": decision="reject". A date value present in ENTITIES_JSON
+  or the question is not a real calendar date (e.g. month 13, day 40).
+- "insufficient_information": decision="reject". There is too little information
+  to even ask one targeted clarifying question (distinct from "missing_required_fields",
+  which still has enough context to ask for exactly the one missing thing).
 
 Rules:
 - For chart requests, required fields are metric and chart_type.

--- a/src/planners/langchain/request_orchestrator.py
+++ b/src/planners/langchain/request_orchestrator.py
@@ -42,12 +42,17 @@ class VisualizationRequestOutcome:
 
 
 _ORCHESTRATOR_ENABLED = env_util.env_flag("ACTIONS_LLM_REQUEST_ORCHESTRATOR_ENABLED", default=True)
-_ORCHESTRATOR_TIMEOUT_RAW = env_util.get_env("ACTIONS_LLM_REQUEST_ORCHESTRATOR_TIMEOUT_SECONDS", default="10") or "10"
-_orchestrator_timeout_value = 10.0
+# This call shares the same underlying model/latency profile as plan
+# generation (see _PLANNER_REQUEST_TIMEOUT_SECONDS in pipeline.py), so a 10s
+# cap was too tight for the same reason -- it just failed more quietly here,
+# since a timeout falls through to the coarser fallback-to-plan path instead
+# of a loud per-attempt error.
+_ORCHESTRATOR_TIMEOUT_RAW = env_util.get_env("ACTIONS_LLM_REQUEST_ORCHESTRATOR_TIMEOUT_SECONDS", default="20") or "20"
+_orchestrator_timeout_value = 20.0
 try:
     _orchestrator_timeout_value = max(1.0, float(_ORCHESTRATOR_TIMEOUT_RAW))
 except Exception:
-    _orchestrator_timeout_value = 10.0
+    _orchestrator_timeout_value = 20.0
 _ORCHESTRATOR_TIMEOUT_SECONDS = _orchestrator_timeout_value
 
 # Single source of truth for plan-generation retry count. Previously duplicated
@@ -64,13 +69,22 @@ _PLANNER_MAX_RETRIES = 2
 # (attempts * per-attempt budget), not just one attempt. It used to only account for
 # one, so on anything slow enough to need a retry, this outer wrapper killed the call
 # before generate_analysis_plan's own retry ever got a chance to run.
+#
+# Since the plan-critique pass (pipeline.py's _critique_plan), each attempt can make
+# TWO LLM calls -- the plan generation itself, then the critique review of it -- each
+# independently bounded by _PLANNER_REQUEST_TIMEOUT_SECONDS. This formula previously
+# still budgeted for one call per attempt, so a scenario whose plan legitimately needs
+# every retry (critique keeps finding real, distinct issues -- observed live for the
+# "10 line graphs" case) could exhaust this outer timeout entirely before the inner
+# loop's own attempts ran out, turning a slow-but-eventually-correct plan into a hard
+# failure instead.
 _PLAN_GENERATION_TIMEOUT_RAW = env_util.get_env("ACTIONS_LLM_PLAN_GENERATION_TIMEOUT_SECONDS", default="") or ""
 try:
     _plan_generation_timeout_value = max(1.0, float(_PLAN_GENERATION_TIMEOUT_RAW))
 except Exception:
     _plan_generation_timeout_value = max(
         _ORCHESTRATOR_TIMEOUT_SECONDS,
-        _PLANNER_REQUEST_TIMEOUT_SECONDS * (_PLANNER_MAX_RETRIES + 1) + 10.0,
+        _PLANNER_REQUEST_TIMEOUT_SECONDS * (_PLANNER_MAX_RETRIES + 1) * 2 + 10.0,
     )
 _PLAN_GENERATION_TIMEOUT_SECONDS = _plan_generation_timeout_value
 
@@ -320,6 +334,85 @@ def _coerce_options(raw: Any) -> List[str]:
 def _is_missing_chart_type_only(missing_fields: List[str]) -> bool:
     normalized = [field.strip().lower() for field in missing_fields if field and field.strip()]
     return bool(normalized) and all(field == "chart_type" for field in normalized)
+
+
+# Required fields per decision_system.txt's own rules ("required fields are
+# metric and chart_type" / "...metric and statistical_test_type") where
+# "present in ENTITIES_JSON" is an unambiguous, objective presence check --
+# unlike e.g. "two distinct statistical cohorts", which needs judgment beyond
+# "some value exists" and is deliberately excluded here.
+_SELF_VERIFIABLE_REQUIRED_FIELDS = {"metric", "chart_type", "statistical_test_type"}
+
+# Any of these being present in ENTITIES_JSON is objective proof a request is
+# in-scope, not just a present "metric": Rasa only ever extracts these within
+# this domain's own SSOT-defined entity types, and this action only runs for
+# intents Rasa already classified as visualization-related in the first
+# place. Deliberately excludes generic/structural entities (limit, offset,
+# sort) that aren't themselves clinical-domain signals. Observed live: "show
+# only patients older than 60" (a bare age filter, no metric yet) got
+# rejected as out_of_scope with the message "This request is not related to
+# clinical stroke-care analytics" -- objectively false, it's a well-formed
+# partial clinical request missing a metric, which is a clarify.
+_SCOPE_PROVING_ENTITY_KEYS = {
+    "metric",
+    "chart_type",
+    "statistical_test_type",
+    "group_by",
+    "stroke_type",
+    "country_code",
+    "sex",
+    "age",
+    "nihss",
+    "hospital_name",
+    "provider_group_name",
+    "boolean_type",
+    "date",
+    "operator_type",
+    "hospital_scope_reference",
+    "group_id",
+}
+
+# decision_system.txt's own closed reason taxonomy: each value unambiguously
+# implies exactly one decision. Observed live (CVaLab): the decision stage
+# occasionally puts a reason value straight into the "decision" field (e.g.
+# {"decision": "ambiguous_request", ...} -- reproducible twice in a row for
+# the same input, not one-off noise, so a same-prompt retry alone doesn't
+# reliably recover it). Since each reason already tells us the decision the
+# model meant, this recovers losslessly rather than failing outright.
+_REASON_IMPLIES_DECISION: Dict[str, str] = {
+    "all_required_fields_present": "proceed",
+    "missing_required_fields": "clarify",
+    "ambiguous_request": "clarify",
+    "out_of_scope": "reject",
+    "invalid_date_format": "reject",
+    "insufficient_information": "reject",
+}
+
+
+def _entity_present(entities: Dict[str, Any], key: str) -> bool:
+    value = entities.get(key)
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(isinstance(item, str) and item.strip() for item in cast(List[Any], value))
+    return value is not None and value is not False
+
+
+def _drop_falsely_missing_fields(missing_fields: List[str], entities: Dict[str, Any]) -> List[str]:
+    """Cross-check the decision stage's own missing_fields claim against the
+    same ENTITIES_JSON it was given. Observed intermittently: the LLM claims
+    "metric" (sometimes others) is missing on a terse follow-up turn even
+    though it's plainly present in ENTITIES_JSON -- a self-contradiction
+    against its own stated rule ("if required fields are present, return
+    proceed"), not a real ambiguity. Scoped to _SELF_VERIFIABLE_REQUIRED_FIELDS
+    so this only overrides objectively-false claims, never a field that
+    genuinely needs semantic judgment to consider satisfied.
+    """
+    return [
+        field
+        for field in missing_fields
+        if not (field.strip().lower() in _SELF_VERIFIABLE_REQUIRED_FIELDS and _entity_present(entities, field.strip().lower()))
+    ]
 
 
 def _has_statistical_test_signal(question: str, entities: Dict[str, Any]) -> bool:
@@ -1053,14 +1146,34 @@ def _decision_stage(
         "chart_types_json": json.dumps(_chart_types(), ensure_ascii=False),
         "conversation_history_json": json.dumps(conversation_history or [], ensure_ascii=False),
     }
-    parsed = _invoke_chain(chain, payload)
-    logger.info("Decision stage raw response: %s", parsed)
 
-    decision_raw = str(parsed.get("decision") or "").strip().lower()
-    if decision_raw not in {"proceed", "clarify", "reject"}:
-        raise ValueError("Invalid decision from decision stage")
+    # One retry on a malformed decision value: unlike generate_analysis_plan
+    # (pipeline.py), which already retries with validation feedback on a bad
+    # response, this call previously had zero retry -- any single malformed
+    # "decision" (observed live via CVaLab, outside {proceed, clarify,
+    # reject}) fell straight through to orchestrate_visualization_request's
+    # generic exception handler ("orchestrator_failed", a vague "I need more
+    # detail" message even for a well-formed request). A same-input retry is
+    # cheap and mirrors the plan-generation stage's own established pattern.
+    parsed: Dict[str, Any] = {}
+    decision_raw = ""
+    recovered_reason: Optional[str] = None
+    last_bad_decision: Optional[str] = None
+    for attempt in range(2):
+        parsed = _invoke_chain(chain, payload)
+        logger.info("Decision stage raw response (attempt %d): %s", attempt + 1, parsed)
+        decision_raw = str(parsed.get("decision") or "").strip().lower()
+        if decision_raw in {"proceed", "clarify", "reject"}:
+            break
+        if decision_raw in _REASON_IMPLIES_DECISION:
+            recovered_reason = decision_raw
+            decision_raw = _REASON_IMPLIES_DECISION[decision_raw]
+            break
+        last_bad_decision = decision_raw
+    else:
+        raise ValueError(f"Invalid decision from decision stage after retry: {last_bad_decision!r}")
 
-    reason = str(parsed.get("reason") or "").strip() or "llm_orchestrator"
+    reason = recovered_reason or str(parsed.get("reason") or "").strip() or "llm_orchestrator"
     missing_fields = _coerce_missing_fields(parsed.get("missing_fields"))
     clarification_type = parsed.get("clarification_type")
     clarification_options = _coerce_options(parsed.get("clarification_options"))
@@ -1075,6 +1188,73 @@ def _decision_stage(
         clarification_options=clarification_options,
         missing_fields=missing_fields,
     )
+
+    # Deterministic safeguard: don't trust a missing_fields claim that
+    # contradicts ENTITIES_JSON itself (see _drop_falsely_missing_fields).
+    if outcome.decision != "proceed" and outcome.missing_fields:
+        corrected_missing = _drop_falsely_missing_fields(outcome.missing_fields, entities)
+        if not corrected_missing:
+            return VisualizationRequestOutcome(
+                decision="proceed",
+                reason="all_required_fields_present",
+                message=None,
+                clarification_type=None,
+                clarification_options=[],
+                missing_fields=[],
+            )
+        if corrected_missing != outcome.missing_fields:
+            outcome = VisualizationRequestOutcome(
+                decision=outcome.decision,
+                reason=outcome.reason,
+                message=outcome.message,
+                clarification_type=outcome.clarification_type,
+                clarification_options=outcome.clarification_options,
+                missing_fields=corrected_missing,
+            )
+
+    # Deterministic safeguard: a request with a real, present metric cannot be
+    # genuinely out of scope -- Rasa's own intent routing already established
+    # this is a visualization request before this stage ever runs (this
+    # action only fires for generate_visualization/update_visualization/
+    # clarify_visualization). Observed: the LLM sometimes rejects such a
+    # request as out_of_scope when the actual gap is a missing chart_type --
+    # that's a clarify, not a reject.
+    #
+    # Scoped tightly to reasons that are actually about scope: "reject" is
+    # also legitimately used for unrelated data-validity problems (e.g.
+    # invalid_date_format for a malformed date), which must NOT be silently
+    # waved through just because a metric happens to be present too -- that
+    # was a real regression caught via CVaLab's webapp_negative_invalid_time_period
+    # scenario during this fix's own testing.
+    if (
+        outcome.decision == "reject"
+        and "out_of_scope" in outcome.reason.strip().lower().replace(" ", "_")
+        and any(_entity_present(entities, key) for key in _SCOPE_PROVING_ENTITY_KEYS)
+    ):
+        still_missing = [field for field in ("metric", "chart_type") if not _entity_present(entities, field)]
+        if still_missing:
+            # The LLM's own message text ("This request is not related to...")
+            # came from the wrong reject/out_of_scope judgment being overridden
+            # here -- reusing it verbatim would still show the user a false
+            # claim even though the decision itself is now correct.
+            readable_fields = " and ".join(field.replace("_", " ") for field in still_missing)
+            outcome = VisualizationRequestOutcome(
+                decision="clarify",
+                reason="missing_required_fields",
+                message=f"Please specify the {readable_fields} you'd like to use.",
+                clarification_type=still_missing[0],
+                clarification_options=[],
+                missing_fields=still_missing,
+            )
+        else:
+            outcome = VisualizationRequestOutcome(
+                decision="proceed",
+                reason="all_required_fields_present",
+                message=None,
+                clarification_type=None,
+                clarification_options=[],
+                missing_fields=[],
+            )
 
     # Deterministic safeguard: do not block statistical-test requests on chart_type.
     if (

--- a/tests/test_decision_stage_missing_fields_safeguard.py
+++ b/tests/test_decision_stage_missing_fields_safeguard.py
@@ -1,0 +1,329 @@
+import unittest
+from unittest.mock import patch
+
+from src.planners.langchain.request_orchestrator import (
+    _decision_stage,
+    _drop_falsely_missing_fields,
+    _entity_present,
+)
+
+
+class DropFalselyMissingFieldsTests(unittest.TestCase):
+    def test_drops_metric_when_present_as_string(self) -> None:
+        result = _drop_falsely_missing_fields(["metric"], {"metric": "DTN"})
+        self.assertEqual(result, [])
+
+    def test_drops_metric_when_present_as_list(self) -> None:
+        result = _drop_falsely_missing_fields(["metric"], {"metric": ["DTN"]})
+        self.assertEqual(result, [])
+
+    def test_keeps_metric_when_genuinely_absent(self) -> None:
+        result = _drop_falsely_missing_fields(["metric"], {"chart_type": "LINE"})
+        self.assertEqual(result, ["metric"])
+
+    def test_keeps_metric_when_present_but_blank(self) -> None:
+        result = _drop_falsely_missing_fields(["metric"], {"metric": "   "})
+        self.assertEqual(result, ["metric"])
+
+    def test_only_drops_the_field_thats_actually_present(self) -> None:
+        result = _drop_falsely_missing_fields(["metric", "chart_type"], {"metric": "DTN"})
+        self.assertEqual(result, ["chart_type"])
+
+    def test_does_not_touch_fields_outside_the_self_verifiable_set(self) -> None:
+        # statistical_cohorts needs two distinct cohorts, not just "some value
+        # exists" -- this safeguard must never paper over that with a bare
+        # presence check.
+        result = _drop_falsely_missing_fields(
+            ["statistical_cohorts"],
+            {"statistical_cohorts": ["Hospital A"]},
+        )
+        self.assertEqual(result, ["statistical_cohorts"])
+
+    def test_entity_present_rejects_empty_list(self) -> None:
+        self.assertFalse(_entity_present({"metric": []}, "metric"))
+        self.assertFalse(_entity_present({"metric": [""]}, "metric"))
+
+
+class DecisionStageSafeguardTests(unittest.TestCase):
+    def test_overrides_clarify_when_llm_falsely_claims_metric_missing(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "clarify",
+                "reason": "missing_metric",
+                "missing_fields": ["metric"],
+                "message": "What metric would you like?",
+            },
+        ):
+            outcome = _decision_stage(
+                question="line chart please",
+                entities={"metric": "DTN", "chart_type": "LINE", "country_code": "CZ"},
+                language="en",
+                conversation_history=["show dtn from Czech Republic", "line chart please"],
+            )
+
+        self.assertEqual(outcome.decision, "proceed")
+        self.assertEqual(outcome.reason, "all_required_fields_present")
+        self.assertEqual(outcome.missing_fields, [])
+
+    def test_overrides_reject_when_llm_falsely_claims_metric_missing(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "reject",
+                "reason": "missing_metric",
+                "missing_fields": ["metric"],
+                "message": "Please specify a metric.",
+            },
+        ):
+            outcome = _decision_stage(
+                question="line chart please",
+                entities={"metric": "DTN", "chart_type": "LINE", "hospital_name": "Hospital X"},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "proceed")
+
+    def test_keeps_genuine_missing_field_untouched(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "clarify",
+                "reason": "missing_chart_type",
+                "missing_fields": ["chart_type"],
+                "message": "What chart type would you like?",
+            },
+        ):
+            outcome = _decision_stage(
+                question="show dtn from Czech Republic",
+                entities={"metric": "DTN", "country_code": "CZ"},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "clarify")
+        self.assertEqual(outcome.missing_fields, ["chart_type"])
+
+    def test_narrows_missing_fields_to_only_the_genuine_one(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "clarify",
+                "reason": "missing_fields",
+                "missing_fields": ["metric", "chart_type"],
+                "message": "What metric and chart type?",
+            },
+        ):
+            outcome = _decision_stage(
+                question="show me something",
+                entities={"metric": "DTN", "country_code": "CZ"},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "clarify")
+        self.assertEqual(outcome.missing_fields, ["chart_type"])
+
+
+class DecisionStageOutOfScopeSafeguardTests(unittest.TestCase):
+    def test_reclassifies_out_of_scope_reject_with_missing_chart_type_as_clarify(self) -> None:
+        """Regression test for a reported CVaLab failure: 'Make a graph for
+        dtn for male ischemic patients from 2025 to 2026' -- a well-formed
+        chart request with a real metric, filters, and a date range -- was
+        rejected as out_of_scope, when the LLM's own message ("Chart requests
+        must specify a chart type") shows the actual gap is just a missing
+        chart_type. A present, valid metric is proof the request is in scope
+        (Rasa's own intent routing already established that before this
+        action ever runs), so this can never legitimately be a scope
+        rejection.
+        """
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "reject",
+                "reason": "out_of_scope",
+                "missing_fields": [],
+                "message": "Chart requests must specify a chart type.",
+            },
+        ):
+            outcome = _decision_stage(
+                question="Make a graph for dtn for male ischemic patients from 2025 to 2026",
+                entities={"metric": "DTN", "sex": "MALE", "stroke_type": "ISCHEMIC", "date": ["2025-01-01", "2026-12-31"]},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "clarify")
+        self.assertEqual(outcome.missing_fields, ["chart_type"])
+        self.assertEqual(outcome.reason, "missing_required_fields")
+
+    def test_reclassifies_out_of_scope_reject_as_proceed_when_all_fields_present(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "reject",
+                "reason": "out_of_scope",
+                "missing_fields": [],
+                "message": "Not a visualization request.",
+            },
+        ):
+            outcome = _decision_stage(
+                question="dtn line chart",
+                entities={"metric": "DTN", "chart_type": "LINE"},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "proceed")
+        self.assertEqual(outcome.reason, "all_required_fields_present")
+
+    def test_leaves_genuine_out_of_scope_reject_untouched_when_no_metric(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "reject",
+                "reason": "out_of_scope",
+                "missing_fields": [],
+                "message": "This doesn't look like a visualization request.",
+            },
+        ):
+            outcome = _decision_stage(
+                question="what's the weather like today",
+                entities={},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "reject")
+        self.assertEqual(outcome.reason, "out_of_scope")
+
+    def test_reclassifies_out_of_scope_reject_for_bare_age_filter_with_no_metric(self) -> None:
+        """Regression test for a reported CVaLab failure: 'show only patients
+        older than 60' (a bare age filter, no metric stated yet) was rejected
+        as out_of_scope with the message 'This request is not related to
+        clinical stroke-care analytics' -- objectively false, since Rasa only
+        ever extracts an "age" entity within this domain. The old safeguard
+        only recognized a present "metric" as scope-proof, missing this case
+        entirely (no metric here at all). Also checks the corrected message
+        doesn't repeat the false "not related to..." claim.
+        """
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "reject",
+                "reason": "out_of_scope",
+                "missing_fields": [],
+                "message": "This request is not related to clinical stroke-care analytics.",
+            },
+        ):
+            outcome = _decision_stage(
+                question="show only patients older than 60",
+                entities={"age": "60"},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "clarify")
+        self.assertEqual(outcome.reason, "missing_required_fields")
+        self.assertIn("metric", outcome.missing_fields)
+        self.assertNotIn("not related", (outcome.message or "").lower())
+
+    def test_does_not_touch_a_reject_for_an_unrelated_data_validity_reason(self) -> None:
+        """Regression test for a bug this safeguard itself introduced (caught
+        by CVaLab's webapp_negative_invalid_time_period scenario): a reject
+        for a genuinely invalid date ("2023-13-40" -- month 13 doesn't exist)
+        was being waved through to "proceed" just because a metric happened
+        to be present too. The safeguard's premise (a present metric
+        disproves an out-of-scope claim) says nothing about date validity --
+        it must only fire for reasons that are actually about scope.
+        """
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={
+                "decision": "reject",
+                "reason": "invalid_date_format",
+                "missing_fields": [],
+                "message": "The date format is incorrect. Please provide valid dates.",
+            },
+        ):
+            outcome = _decision_stage(
+                question="Show me a line graph of DTN from 2023-13-01 to 2023-13-40",
+                entities={"chart_type": "LINE", "metric": "DTN", "date": ["2023-13-01", "2023-13-40"]},
+                language="en",
+            )
+
+        self.assertEqual(outcome.decision, "reject")
+        self.assertEqual(outcome.reason, "invalid_date_format")
+
+
+class DecisionStageInvalidDecisionRetryTests(unittest.TestCase):
+    """Regression tests for a real caught exception (CVaLab: 'show a line
+    graph of age grouped by sex' -> ValueError: Invalid decision from
+    decision stage -> generic 'orchestrator_failed' clarify for a perfectly
+    well-formed request). Unlike generate_analysis_plan in pipeline.py, this
+    call previously had zero retry on a malformed response.
+    """
+
+    def test_retries_once_and_succeeds_on_second_attempt(self) -> None:
+        responses = [
+            {"decision": "maybe", "reason": "unsure", "missing_fields": []},
+            {"decision": "proceed", "reason": "all_required_fields_present", "missing_fields": []},
+        ]
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            side_effect=responses,
+        ) as mocked:
+            outcome = _decision_stage(
+                question="show a line graph of age grouped by sex",
+                entities={"metric": "AGE", "chart_type": "LINE", "group_by": "SEX"},
+                language="en",
+            )
+
+        self.assertEqual(mocked.call_count, 2)
+        self.assertEqual(outcome.decision, "proceed")
+
+    def test_first_attempt_success_does_not_retry(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={"decision": "proceed", "reason": "all_required_fields_present", "missing_fields": []},
+        ) as mocked:
+            _decision_stage(question="dtn line chart", entities={"metric": "DTN", "chart_type": "LINE"}, language="en")
+
+        self.assertEqual(mocked.call_count, 1)
+
+    def test_raises_with_the_bad_value_after_two_failed_attempts(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={"decision": "maybe", "reason": "unsure", "missing_fields": []},
+        ) as mocked:
+            with self.assertRaises(ValueError) as ctx:
+                _decision_stage(question="dtn line chart", entities={"metric": "DTN", "chart_type": "LINE"}, language="en")
+
+        self.assertEqual(mocked.call_count, 2)
+        self.assertIn("maybe", str(ctx.exception))
+
+    def test_recovers_when_llm_puts_a_reason_value_in_the_decision_field(self) -> None:
+        """Regression test for the exact live CVaLab failure: 'show a line
+        graph of age grouped by sex' got {"decision": "ambiguous_request",
+        ...} on both attempts (not one-off noise -- same wrong value twice in
+        a row), which the plain retry alone couldn't recover. Since each
+        reason value in the closed taxonomy unambiguously implies its
+        decision, this is losslessly recoverable on the first attempt.
+        """
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={"decision": "ambiguous_request", "missing_fields": []},
+        ) as mocked:
+            outcome = _decision_stage(
+                question="show a line graph of age grouped by sex",
+                entities={"metric": "AGE", "group_by": "SEX"},
+                language="en",
+            )
+
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual(outcome.decision, "clarify")
+        self.assertEqual(outcome.reason, "ambiguous_request")
+
+    def test_recovers_out_of_scope_reason_swapped_into_decision_as_reject(self) -> None:
+        with patch(
+            "src.planners.langchain.request_orchestrator._invoke_chain",
+            return_value={"decision": "out_of_scope", "missing_fields": []},
+        ):
+            outcome = _decision_stage(question="what's the weather", entities={}, language="en")
+
+        self.assertEqual(outcome.decision, "reject")
+        self.assertEqual(outcome.reason, "out_of_scope")

--- a/tests/test_extract_entities_from_latest_message.py
+++ b/tests/test_extract_entities_from_latest_message.py
@@ -1,0 +1,136 @@
+from src.actions.helpers.visualization import extract_entities_from_latest_message
+
+
+def _message(entities):
+    return {"entities": entities}
+
+
+def test_repeated_identical_entity_value_stays_a_scalar() -> None:
+    """Regression test: "make two line charts, one of male patients DTN,
+    the other of female patients DTN" mentions DTN twice -- once per chart,
+    not as two distinct metric answers. Turning that into metric=["DTN",
+    "DTN"] previously read to the decision-stage LLM as two different
+    metric candidates to choose between, producing a spurious "which
+    metric?" clarification for an otherwise unambiguous request.
+    """
+    entities = extract_entities_from_latest_message(
+        _message(
+            [
+                {"entity": "chart_type", "value": "LINE"},
+                {"entity": "sex", "value": "MALE"},
+                {"entity": "metric", "value": "DTN"},
+                {"entity": "sex", "value": "FEMALE"},
+                {"entity": "metric", "value": "DTN"},
+            ]
+        )
+    )
+
+    assert entities["metric"] == "DTN"
+    assert entities["sex"] == ["MALE", "FEMALE"]
+
+
+def test_repeated_distinct_entity_values_still_become_a_list() -> None:
+    entities = extract_entities_from_latest_message(
+        _message(
+            [
+                {"entity": "group_id", "value": "289"},
+                {"entity": "group_id", "value": "252"},
+            ]
+        )
+    )
+
+    assert entities["group_id"] == ["289", "252"]
+
+
+def test_repeated_distinct_values_in_an_existing_list_are_appended_once() -> None:
+    entities = extract_entities_from_latest_message(
+        _message(
+            [
+                {"entity": "group_id", "value": "289"},
+                {"entity": "group_id", "value": "252"},
+                {"entity": "group_id", "value": "289"},
+                {"entity": "group_id", "value": "10"},
+            ]
+        )
+    )
+
+    assert entities["group_id"] == ["289", "252", "10"]
+
+
+def test_regex_only_entity_dropped_when_diet_claims_the_same_span_differently() -> None:
+    """Regression test: "Show me a bar chart of DTN grouped by age in
+    10-year buckets" -- DIETClassifier correctly tags "age" as group_by only,
+    but RegexEntityExtractor's SSOT lookup table also matches the literal
+    word "age" as a metric (it's a legitimate metric name elsewhere), at the
+    exact same character span. That regex-only reading of the same tokens
+    DIET already assigned to group_by is a false positive, not a second
+    metric candidate -- it previously produced metric=["DTN", "AGE"], read by
+    the decision-stage LLM as genuine ambiguity for an unambiguous request.
+    """
+    entities = extract_entities_from_latest_message(
+        _message(
+            [
+                {
+                    "entity": "metric",
+                    "value": "DTN",
+                    "start": 23,
+                    "end": 26,
+                    "extractors": [{"extractor": "DIETClassifier"}, {"extractor": "RegexEntityExtractor"}],
+                },
+                {
+                    "entity": "group_by",
+                    "value": "AGE",
+                    "start": 38,
+                    "end": 41,
+                    "extractors": [{"extractor": "DIETClassifier"}, {"extractor": "RegexEntityExtractor"}],
+                },
+                {
+                    "entity": "metric",
+                    "value": "AGE",
+                    "start": 38,
+                    "end": 41,
+                    "extractors": [{"extractor": "RegexEntityExtractor"}],
+                },
+                {
+                    "entity": "group_by",
+                    "value": "YEAR",
+                    "start": 48,
+                    "end": 52,
+                    "extractors": [{"extractor": "RegexEntityExtractor"}],
+                },
+            ]
+        )
+    )
+
+    assert entities["metric"] == "DTN"
+    # "YEAR" has no competing DIET tag at its span at all (DIET didn't tag
+    # those tokens as anything), so it isn't a same-span contradiction --
+    # only entities that DIET actively assigned to a *different* type at the
+    # same span get dropped.
+    assert entities["group_by"] == ["AGE", "YEAR"]
+
+
+def test_regex_only_entity_kept_when_diet_agrees_or_is_silent() -> None:
+    entities = extract_entities_from_latest_message(
+        _message(
+            [
+                {
+                    "entity": "metric",
+                    "value": "DTN",
+                    "start": 0,
+                    "end": 3,
+                    "extractors": [{"extractor": "DIETClassifier"}, {"extractor": "RegexEntityExtractor"}],
+                },
+                {
+                    "entity": "limit",
+                    "value": "10",
+                    "start": 10,
+                    "end": 12,
+                    "extractors": [{"extractor": "RegexEntityExtractor"}],
+                },
+            ]
+        )
+    )
+
+    assert entities["metric"] == "DTN"
+    assert entities["limit"] == "10"

--- a/tests/test_schema_filter_list_normalization.py
+++ b/tests/test_schema_filter_list_normalization.py
@@ -1,0 +1,93 @@
+import unittest
+
+from src.domain.langchain.schema import AnalysisPlan, ChartSpec, StatisticalTestSpec
+
+
+class FilterListNormalizationTests(unittest.TestCase):
+    """Regression tests for a real CVaLab-caught bug: the planner LLM
+    sometimes emits "filters" as a bare JSON list (e.g.
+    [{"type": "SexFilter", "value": "MALE"}]) instead of a single FilterNode
+    object, causing an 18-way pydantic ValidationError (one failure per
+    FilterNode union member) that discarded an otherwise-correct plan and
+    fell through to a generic "I need a bit more detail" clarify.
+    """
+
+    def test_single_element_list_unwraps_to_the_bare_filter(self) -> None:
+        chart = ChartSpec.model_validate(
+            {
+                "chart_type": "LINE",
+                "filters": [{"type": "SexFilter", "value": "MALE"}],
+                "metrics": [{"metric": "DTN"}],
+            }
+        )
+        self.assertEqual(chart.filters.type, "SexFilter")
+        self.assertEqual(chart.filters.value, "MALE")
+
+    def test_multi_element_list_wraps_in_and_filter(self) -> None:
+        chart = ChartSpec.model_validate(
+            {
+                "chart_type": "LINE",
+                "filters": [
+                    {"type": "SexFilter", "value": "MALE"},
+                    {"type": "StrokeFilter", "value": "ISCHEMIC"},
+                ],
+                "metrics": [{"metric": "DTN"}],
+            }
+        )
+        self.assertEqual(chart.filters.type, "AndFilter")
+        self.assertEqual(len(chart.filters.and_), 2)
+
+    def test_empty_list_normalizes_to_none(self) -> None:
+        chart = ChartSpec.model_validate(
+            {"chart_type": "LINE", "filters": [], "metrics": [{"metric": "DTN"}]}
+        )
+        self.assertIsNone(chart.filters)
+
+    def test_bare_object_is_unaffected(self) -> None:
+        chart = ChartSpec.model_validate(
+            {
+                "chart_type": "LINE",
+                "filters": {"type": "SexFilter", "value": "MALE"},
+                "metrics": [{"metric": "DTN"}],
+            }
+        )
+        self.assertEqual(chart.filters.type, "SexFilter")
+
+    def test_absent_filters_stays_none(self) -> None:
+        chart = ChartSpec.model_validate({"chart_type": "LINE", "metrics": [{"metric": "DTN"}]})
+        self.assertIsNone(chart.filters)
+
+    def test_statistical_test_spec_gets_the_same_normalization(self) -> None:
+        spec = StatisticalTestSpec.model_validate(
+            {
+                "test_type": "MANN_WHITNEY_U_TEST",
+                "metrics": [{"metric": "DTN"}],
+                "filters": [{"type": "SexFilter", "value": "MALE"}],
+            }
+        )
+        self.assertEqual(spec.filters.type, "SexFilter")
+
+    def test_full_plan_with_the_exact_reported_shape_validates(self) -> None:
+        """The exact plan shape from the CVaLab failure: 'make two line
+        charts, one of male patients DTN, the other of female patients DTN'.
+        """
+        plan = AnalysisPlan.model_validate(
+            {
+                "charts": [
+                    {
+                        "chart_type": "LINE",
+                        "filters": [{"type": "SexFilter", "value": "MALE"}],
+                        "semantics": {"intent": "TREND", "measure": {"type": "MEAN"}},
+                        "metrics": [{"metric": "DTN"}],
+                    },
+                    {
+                        "chart_type": "LINE",
+                        "filters": [{"type": "SexFilter", "value": "FEMALE"}],
+                        "semantics": {"intent": "TREND", "measure": {"type": "MEAN"}},
+                        "metrics": [{"metric": "DTN"}],
+                    },
+                ]
+            }
+        )
+        self.assertEqual(plan.charts[0].filters.value, "MALE")
+        self.assertEqual(plan.charts[1].filters.value, "FEMALE")

--- a/tests/test_time_grouping_month_axis.py
+++ b/tests/test_time_grouping_month_axis.py
@@ -59,6 +59,95 @@ class TimeGroupingMonthAxisTests(unittest.TestCase):
         self.assertEqual(len(series[0].data), 1)
         self.assertEqual(series[0].data[0].x, "2023-02")
 
+    def test_map_metrics_payload_to_series_uses_day_labels_for_daily_buckets(self) -> None:
+        """Regression test: a 'last 30 days, daily' request previously
+        rendered as if it had ~2 data points, because every single-day
+        bucket in the same month collapsed onto the same "%Y-%m" label.
+        Distinct day buckets must get distinct, day-precision labels.
+        """
+        kpis = [
+            SimpleNamespace(
+                kpi1=SimpleNamespace(median=None, mean=float(i), case_count=[], d1=None),
+                grouped_by=None,
+                time_period=SimpleNamespace(start_date=f"2026-07-{6 + i:02d}", end_date=f"2026-07-{6 + i:02d}"),
+                data_origin=None,
+            )
+            for i in range(5)
+        ]
+        metric_payload = {"metric_DTN": SimpleNamespace(kpi_group=kpis)}
+
+        series = map_metrics_payload_to_series(
+            metrics_payload=metric_payload,
+            label_parts=[],
+            include_metric_alias=True,
+            group_by_field=None,
+            add_time_period_labels=True,
+        )
+
+        x_values = [point.x for s in series for point in s.data]
+        self.assertEqual(x_values, ["2026-07-06", "2026-07-07", "2026-07-08", "2026-07-09", "2026-07-10"])
+        self.assertEqual(len(set(x_values)), 5, "distinct day buckets must not share a label")
+
+    def test_map_metrics_payload_to_series_uses_quarter_label_for_calendar_quarter(self) -> None:
+        kpi = SimpleNamespace(
+            kpi1=SimpleNamespace(median=None, mean=14.0, case_count=[], d1=None),
+            grouped_by=None,
+            time_period=SimpleNamespace(start_date="2023-04-01", end_date="2023-06-30"),
+            data_origin=None,
+        )
+        metric_payload = {"metric_DTN": SimpleNamespace(kpi_group=[kpi])}
+
+        series = map_metrics_payload_to_series(
+            metrics_payload=metric_payload,
+            label_parts=[],
+            include_metric_alias=True,
+            group_by_field=None,
+            add_time_period_labels=True,
+        )
+
+        self.assertEqual(series[0].data[0].x, "2023-Q2")
+
+    def test_map_metrics_payload_to_series_uses_year_label_for_calendar_year(self) -> None:
+        kpi = SimpleNamespace(
+            kpi1=SimpleNamespace(median=None, mean=14.0, case_count=[], d1=None),
+            grouped_by=None,
+            time_period=SimpleNamespace(start_date="2023-01-01", end_date="2023-12-31"),
+            data_origin=None,
+        )
+        metric_payload = {"metric_DTN": SimpleNamespace(kpi_group=[kpi])}
+
+        series = map_metrics_payload_to_series(
+            metrics_payload=metric_payload,
+            label_parts=[],
+            include_metric_alias=True,
+            group_by_field=None,
+            add_time_period_labels=True,
+        )
+
+        self.assertEqual(series[0].data[0].x, "2023")
+
+    def test_map_metrics_payload_to_series_uses_full_date_for_non_calendar_aligned_span(self) -> None:
+        """A week-ish bucket that doesn't line up with a calendar month/
+        quarter/year boundary must fall back to full date precision, not be
+        mistaken for one of those and mislabeled."""
+        kpi = SimpleNamespace(
+            kpi1=SimpleNamespace(median=None, mean=14.0, case_count=[], d1=None),
+            grouped_by=None,
+            time_period=SimpleNamespace(start_date="2023-02-06", end_date="2023-02-12"),
+            data_origin=None,
+        )
+        metric_payload = {"metric_DTN": SimpleNamespace(kpi_group=[kpi])}
+
+        series = map_metrics_payload_to_series(
+            metrics_payload=metric_payload,
+            label_parts=[],
+            include_metric_alias=True,
+            group_by_field=None,
+            add_time_period_labels=True,
+        )
+
+        self.assertEqual(series[0].data[0].x, "2023-02-06")
+
     def test_map_metrics_payload_to_series_emits_missing_time_point_as_null(self) -> None:
         kpi = SimpleNamespace(
             kpi1=SimpleNamespace(

--- a/tests/test_visualization_context_entities.py
+++ b/tests/test_visualization_context_entities.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 
-def _load_merge_latest_with_thread_entities():
+def _load_visualization_context_helpers():
     source_path = Path(__file__).resolve().parents[1] / "src" / "actions" / "actions" / "visualization_action.py"
     source = source_path.read_text(encoding="utf-8")
     module_ast = ast.parse(source, filename=str(source_path))
@@ -20,9 +20,11 @@ def _load_merge_latest_with_thread_entities():
         "_is_visualization_payload",
         "_event_has_visualization_signal",
         "_find_latest_visualization_anchor_user_ordinal",
+        "_is_awaiting_clarification_reply",
+        "_should_carry_forward_visualization_context",
     }
 
-    required_assigns = {"_LATEST_ENTITY_PRECEDENCE_KEYS", "_LATEST_ENTITY_CLEAR_ON_ABSENCE_KEYS"}
+    required_assigns = {"_LATEST_ENTITY_PRECEDENCE_KEYS"}
 
     selected = [
         node
@@ -54,7 +56,11 @@ def _load_merge_latest_with_thread_entities():
         "_VISUALIZATION_RESPONSE_SCHEMA_VERSION": 1,
     }
     exec(compile(isolated_module, filename=str(source_path), mode="exec"), namespace)
-    return namespace["merge_latest_with_thread_entities"]
+    return namespace
+
+
+def _load_merge_latest_with_thread_entities():
+    return _load_visualization_context_helpers()["merge_latest_with_thread_entities"]
 
 
 def _user_event(text: str, intent: str, entities: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -161,9 +167,11 @@ def test_merge_latest_with_thread_entities_keeps_latest_provider_scope_keys() ->
 
     assert merged["hospital_name"] == ["Aalborg University - Hospital", "Kronborg Castle Hospital"]
     assert merged["date"] == ["2024-01-01", "2026-12-31"]
-    # group_id wasn't restated by the latest turn, so the earlier turn's value
-    # must be dropped rather than carried forward.
-    assert "group_id" not in merged
+    # group_id wasn't restated by the latest turn, but merge_latest_with_thread_entities
+    # always carries the thread forward once called -- it's the caller's job
+    # (_should_carry_forward_visualization_context) to decide whether to call it
+    # at all for a given turn, not this function's job to selectively drop keys.
+    assert merged["group_id"] == ["provider group 2825", "provider group 3001"]
 
 
 def test_merge_latest_with_thread_entities_keeps_latest_provider_group_ids() -> None:
@@ -192,11 +200,20 @@ def test_merge_latest_with_thread_entities_keeps_latest_provider_group_ids() -> 
     assert merged["date"] == ["2024-01-01", "2026-12-31"]
 
 
-def test_merge_latest_with_thread_entities_drops_stale_hospital_comparison_scope() -> None:
+def test_fresh_generate_visualization_does_not_carry_forward_stale_hospital_scope() -> None:
     """Regression test for a reported carryover bug: after a Mann-Whitney
     comparison names a specific hospital, an unrelated single-metric follow-up
-    request that names no hospital must not inherit it."""
-    merge_latest_with_thread_entities = _load_merge_latest_with_thread_entities()
+    request that names no hospital must not inherit it.
+
+    This used to be enforced inside merge_latest_with_thread_entities itself
+    (a "clear on absence" rule for identity keys). It's now enforced one layer
+    up: a fresh generate_visualization that isn't completing a pending
+    clarification simply never calls merge_latest_with_thread_entities at
+    all -- see _should_carry_forward_visualization_context and its callers in
+    visualization_action.py.
+    """
+    helpers = _load_visualization_context_helpers()
+    should_carry_forward = helpers["_should_carry_forward_visualization_context"]
     events = [
         _user_event(
             "Can you compare my dtn against army alhama de murcia hospital using a mann whitney u test",
@@ -220,17 +237,97 @@ def test_merge_latest_with_thread_entities_drops_stale_hospital_comparison_scope
         ),
     ]
 
-    merged = merge_latest_with_thread_entities(
-        latest_entities={
-            "chart_type": "BAR",
-            "metric": "STROKE_TYPE",
-            "group_by": "STROKE_TYPE",
+    latest_entities = {
+        "chart_type": "BAR",
+        "metric": "STROKE_TYPE",
+        "group_by": "STROKE_TYPE",
+    }
+
+    # A fresh generate_visualization, with no pending clarification in play
+    # (no bot decision event at all here), must not carry the thread forward.
+    assert should_carry_forward("generate_visualization", events) is False
+    # So the caller uses latest_entities as-is -- nothing from the earlier
+    # Mann-Whitney turn (hospital, country, comparison group_by) leaks in.
+    assert "hospital_name" not in latest_entities
+    assert "hospital_scope_reference" not in latest_entities
+    assert "country_code" not in latest_entities
+    assert latest_entities["metric"] == "STROKE_TYPE"
+
+
+def test_should_carry_forward_true_for_update_and_terse_clarify_intents() -> None:
+    helpers = _load_visualization_context_helpers()
+    should_carry_forward = helpers["_should_carry_forward_visualization_context"]
+
+    # update_visualization always carries the thread forward: it's explicitly
+    # a request to modify the existing plan.
+    assert should_carry_forward("update_visualization", []) is True
+    # clarify_visualization carries forward even with no pending clarification
+    # in the events -- its NLU training data is terse follow-on instructions
+    # ("group by X") that only make sense as a modification of the current
+    # chart, not a standalone request.
+    assert should_carry_forward("clarify_visualization", []) is True
+
+
+def test_should_carry_forward_true_while_awaiting_clarification_reply() -> None:
+    """The exact bug from the country_code PR review: 'show dtn from Czech
+    Republic' -> bot asks for chart_type -> user replies 'line chart please'.
+    The reply is classified generate_visualization (not clarify_visualization
+    or update_visualization), but it's completing the pending clarification,
+    not starting a fresh request, so the thread -- and country_code -- must
+    still carry forward.
+    """
+    helpers = _load_visualization_context_helpers()
+    should_carry_forward = helpers["_should_carry_forward_visualization_context"]
+    events = [
+        _user_event(
+            "show dtn from Czech Republic",
+            "generate_visualization",
+            [
+                {"entity": "metric", "value": "DTN"},
+                {"entity": "country_code", "value": "CZ"},
+            ],
+        ),
+        {
+            "event": "bot",
+            "custom": {
+                "type": "visualization_query_decision",
+                "decision": "clarify",
+                "reason": "missing_chart_type",
+            },
         },
+        _user_event("line chart please", "generate_visualization", [{"entity": "chart_type", "value": "LINE"}]),
+    ]
+
+    assert should_carry_forward("generate_visualization", events) is True
+
+    merge_latest_with_thread_entities = _load_merge_latest_with_thread_entities()
+    merged = merge_latest_with_thread_entities(
+        latest_entities={"chart_type": "LINE"},
         events=events,
         fallback_limit=12,
     )
+    assert merged["country_code"] == "CZ"
+    assert merged["metric"] == "DTN"
+    assert merged["chart_type"] == "LINE"
 
-    assert "hospital_name" not in merged
-    assert "hospital_scope_reference" not in merged
-    assert "country_code" not in merged
-    assert merged["metric"] == "STROKE_TYPE"
+
+def test_should_not_carry_forward_after_a_completed_request_with_no_pending_clarification() -> None:
+    """A generate_visualization turn that follows a *successful* (proceed) or
+    rejected prior request -- not a clarify -- is a fresh ask, even though the
+    prior bot turn was itself a visualization_query_decision payload."""
+    helpers = _load_visualization_context_helpers()
+    should_carry_forward = helpers["_should_carry_forward_visualization_context"]
+    events = [
+        _user_event(
+            "compare mine vs Hospital X",
+            "generate_visualization",
+            [{"entity": "hospital_name", "value": "Hospital X"}],
+        ),
+        {
+            "event": "bot",
+            "custom": {"type": "visualization_query_decision", "decision": "proceed"},
+        },
+        _user_event("show me a bar chart of stroke type", "generate_visualization", [{"entity": "chart_type", "value": "BAR"}]),
+    ]
+
+    assert should_carry_forward("generate_visualization", events) is False


### PR DESCRIPTION
Retuned plan-generation/orchestrator timeouts to match real LLM latency and added a plan-critique pass; hardened the decision stage (retry on malformed output, closed reason taxonomy, safeguards against false rejects/false missing-fields); fixed entity extraction to drop spurious duplicate candidates (repeated-value dedup, and dropping regex-lookup-only tags when DIET confidently assigned a different type to the same span); reworked cross-turn context carry-forward so a fresh request no longer inherits a prior turn's hospital/provider; fixed chart bucket labels collapsing daily data onto monthly labels.