### PR TITLE
Strip developer-facing diagnostics/emoji from end-user chat text

### DIFF
--- a/src/actions/actions/guided_visualization_action.py
+++ b/src/actions/actions/guided_visualization_action.py
@@ -34,7 +34,6 @@ logger = logging.getLogger(__name__)
 
 _ECHO_INTERNAL_ERRORS = env_util.env_flag("ACTIONS_ECHO_INTERNAL_ERRORS", default=False)
 _SHOW_EXECUTION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_EXECUTION_SUMMARY", default=True)
-_SHOW_NORMALIZATION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_NORMALIZATION_SUMMARY", default=True)
 _EMIT_QUERY_DEBUG = env_util.env_flag("ACTIONS_EMIT_QUERY_DEBUG", default=False)
 
 _executor_concurrency_raw = env_util.get_env("ACTIONS_EXECUTOR_MAX_CONCURRENCY", default="4") or "4"
@@ -171,14 +170,7 @@ class ActionGuidedGenerateVisualization(Action):  # pyright: ignore
                             dispatcher.utter_message(text=f"Note: {warning.strip()}")
 
                 if _SHOW_EXECUTION_SUMMARY and execution_summary is not None:
-                    dispatcher.utter_message(
-                        text=format_execution_summary(
-                            execution_summary,
-                            show_normalization=_SHOW_NORMALIZATION_SUMMARY,
-                            planner_diagnostics=None,
-                            language=language,
-                        )
-                    )
+                    dispatcher.utter_message(text=format_execution_summary(execution_summary, language=language))
                 else:
                     dispatcher.utter_message(text=translate("action.visualization.success_complete", language=language))
 

--- a/src/actions/actions/hospitals_action.py
+++ b/src/actions/actions/hospitals_action.py
@@ -262,7 +262,7 @@ class ActionListHospitals(Action):  # pyright: ignore
                     ),
                 )
                 language = resolve_language_from_tracker(tracker)
-                dispatcher.utter_message(text=f"❌ {friendly_hospital_error(exc, language=language)}")
+                dispatcher.utter_message(text=friendly_hospital_error(exc, language=language))
                 if _ECHO_INTERNAL_ERRORS:
                     dispatcher.utter_message(
                         text=translate(

--- a/src/actions/actions/metric_action.py
+++ b/src/actions/actions/metric_action.py
@@ -179,7 +179,7 @@ class ActionExplainMetric(Action):  # pyright: ignore
                     ),
                 )
                 language = resolve_language(tracker)
-                dispatcher.utter_message(text=f"❌ {friendly_metric_error(e, language=language)}")
+                dispatcher.utter_message(text=friendly_metric_error(e, language=language))
                 if _ECHO_INTERNAL_ERRORS:
                     dispatcher.utter_message(
                         text=translate(

--- a/src/actions/actions/visualization_action.py
+++ b/src/actions/actions/visualization_action.py
@@ -1423,16 +1423,15 @@ class ActionOneShotGenerateVisualization(LongAction):
                         )
                     )
             finally:
-                if completed_successfully:
-                    if _SHOW_EXECUTION_SUMMARY and execution_summary is not None:
-                        ctx.say(text=format_execution_summary(execution_summary, language=language))
-                    else:
-                        ctx.say(
-                            text=translate(
-                                "action.visualization.success_complete",
-                                language=language,
-                            )
-                        )
+                # _build_confirmation_message already sent the "here's your
+                # X" confirmation above (unconditionally, right after
+                # completed_successfully is set) -- this only adds anything
+                # when there's a genuine caveat (skipped/failed stats) to
+                # report, never a second redundant "here's your chart".
+                if completed_successfully and _SHOW_EXECUTION_SUMMARY and execution_summary is not None:
+                    caveat = format_execution_summary(execution_summary, language=language, include_opening_line=False)
+                    if caveat:
+                        ctx.say(text=caveat)
                     if plan_obj is not None:
                         _emit_next_metric_followup(ctx=ctx, plan_obj=plan_obj, language=language)
                 ctx.done()

--- a/src/actions/actions/visualization_action.py
+++ b/src/actions/actions/visualization_action.py
@@ -37,7 +37,6 @@ _LOG_USER_TEXT = env_util.env_flag("ACTIONS_LOG_USER_TEXT", default=False)
 _ECHO_INTERNAL_ERRORS = env_util.env_flag("ACTIONS_ECHO_INTERNAL_ERRORS", default=False)
 _SHOW_EXECUTION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_EXECUTION_SUMMARY", default=True)
 _DEFER_CALLBACK_HANDOFF = env_util.env_flag("LONG_ACTION_DEFER_CALLBACK_HANDOFF", default=False)
-_SHOW_NORMALIZATION_SUMMARY = env_util.env_flag("ACTIONS_SHOW_NORMALIZATION_SUMMARY", default=True)
 _EMIT_QUERY_DEBUG = env_util.env_flag("ACTIONS_EMIT_QUERY_DEBUG", default=False)
 _VISUALIZATION_CONTINUATION_INTENTS = {
     "generate_visualization",
@@ -193,19 +192,6 @@ def _emit_next_metric_followup(
             },
         ],
     )
-
-
-def _collect_planner_diagnostics() -> Optional[Dict[str, Any]]:
-    # Diagnostics are optional and must never break request handling.
-    try:
-        from src.planners.langchain import pipeline
-
-        diagnostics_any = pipeline.get_plan_cache_diagnostics()
-        if isinstance(diagnostics_any, dict):
-            return cast(Dict[str, Any], diagnostics_any)
-    except Exception:
-        logger.debug("Planner diagnostics unavailable", exc_info=True)
-    return None
 
 
 def _collect_visualization_thread_messages(events: List[Dict[str, Any]], fallback_limit: int = 12) -> List[str]:
@@ -756,7 +742,6 @@ def _extract_request_context(ctx: LongActionContext) -> Dict[str, Any]:
 
 _INTERNAL_TRACE_ID_KEY = "_visualization_trace_id"
 _INTERNAL_PREPARED_PLAN_KEY = "_visualization_prepared_plan"
-_INTERNAL_PLANNER_DIAGNOSTICS_KEY = "_visualization_planner_diagnostics"
 
 
 def _normalize_trace_id(value: Any) -> Optional[str]:
@@ -980,7 +965,6 @@ class ActionOneShotGenerateVisualization(LongAction):
                         )
 
                     ctx.tracker_snapshot[_INTERNAL_PREPARED_PLAN_KEY] = prepared_plan
-                    ctx.tracker_snapshot[_INTERNAL_PLANNER_DIAGNOSTICS_KEY] = _collect_planner_diagnostics()
                     return PreworkResult(
                         events=[SlotSet("awaiting_visualization_clarification", False)],
                         proceed=True,
@@ -1104,7 +1088,6 @@ class ActionOneShotGenerateVisualization(LongAction):
                     )
 
                 ctx.tracker_snapshot[_INTERNAL_PREPARED_PLAN_KEY] = prepared_plan
-                ctx.tracker_snapshot[_INTERNAL_PLANNER_DIAGNOSTICS_KEY] = _collect_planner_diagnostics()
 
                 ctx.say(
                     json_message={
@@ -1167,7 +1150,6 @@ class ActionOneShotGenerateVisualization(LongAction):
     async def work(self, ctx: LongActionContext) -> Any:
         completed_successfully = False
         execution_summary: Optional[Any] = None
-        planner_diagnostics: Optional[Dict[str, Any]] = None
         plan_obj: Optional[lang_schema.AnalysisPlan] = None
         trace_id = _ensure_context_trace_id(ctx)
         language = resolve_language(metadata=ctx.metadata, slots=ctx.slots)
@@ -1220,11 +1202,9 @@ class ActionOneShotGenerateVisualization(LongAction):
                     ctx.enable_callback_mode()
 
                 prepared_any = ctx.tracker_snapshot.pop(_INTERNAL_PREPARED_PLAN_KEY, None)
-                diagnostics_any = ctx.tracker_snapshot.pop(_INTERNAL_PLANNER_DIAGNOSTICS_KEY, None)
 
                 if isinstance(prepared_any, lang_schema.AnalysisPlan):
                     plan_obj = prepared_any
-                    planner_diagnostics = cast(Optional[Dict[str, Any]], diagnostics_any) if isinstance(diagnostics_any, dict) else None
                     progress("Using prepared plan from prework")
                 else:
                     logger.warning(
@@ -1277,7 +1257,6 @@ class ActionOneShotGenerateVisualization(LongAction):
                     plan_obj = outcome.plan if isinstance(outcome.plan, lang_schema.AnalysisPlan) else None
                     if plan_obj is None:
                         raise RuntimeError("Orchestrator returned proceed without an analysis plan")
-                    planner_diagnostics = _collect_planner_diagnostics()
 
                 if plan_obj is not None:
                     empty_plan_message = _build_empty_plan_clarification(plan_obj, language)
@@ -1446,14 +1425,7 @@ class ActionOneShotGenerateVisualization(LongAction):
             finally:
                 if completed_successfully:
                     if _SHOW_EXECUTION_SUMMARY and execution_summary is not None:
-                        ctx.say(
-                            text=format_execution_summary(
-                                execution_summary,
-                                show_normalization=_SHOW_NORMALIZATION_SUMMARY,
-                                planner_diagnostics=planner_diagnostics,
-                                language=language,
-                            )
-                        )
+                        ctx.say(text=format_execution_summary(execution_summary, language=language))
                     else:
                         ctx.say(
                             text=translate(

--- a/src/actions/helpers/visualization.py
+++ b/src/actions/helpers/visualization.py
@@ -485,10 +485,15 @@ def serialize_plan_for_frontend(plan: Any) -> Dict[str, Any]:
 
 def format_execution_summary(
     summary: Dict[str, Any] | Any,
-    show_normalization: bool = True,
-    planner_diagnostics: Optional[Dict[str, Any]] = None,
     language: Optional[str] = None,
 ) -> str:
+    """A short, natural closing line for the chat -- the chart(s)/stat(s)
+    themselves render in the UI, so this doesn't need to describe them in
+    detail, just close the loop conversationally. Diagnostic detail (trace
+    id, cache stats, query batching, plan normalization) used to be dumped
+    here too; that's developer information, not something an end user
+    needs, and CVaLab's own debug chat already surfaces it from the
+    structured payload -- see visualization_plan/visualization_response."""
     def t(key: str, default: str, params: Optional[Dict[str, Any]] = None) -> str:
         return translate(key, language=language, params=params, default=default)
 
@@ -496,327 +501,51 @@ def format_execution_summary(
     if summary_dict is None and isinstance(summary, dict):
         summary_dict = _mapping_to_dict(summary)
     if summary_dict is None:
-        return t("action.summary.complete", "✅ Visualization generation complete.")
+        return t("action.summary.complete_fallback", "Done!")
 
-    estimated = summary_dict.get("estimated_queries")
-    actual = summary_dict.get("actual_queries")
     chart_count = summary_dict.get("chart_count")
     stats_count = summary_dict.get("stats_count")
     stats_skipped = summary_dict.get("stats_skipped")
     stats_errors = summary_dict.get("stats_errors")
-    trace_id = summary_dict.get("trace_id")
-    normalization = _mapping_to_dict(summary_dict.get("normalization")) or None
-    batches_any = summary_dict.get("batches")
-    batches: List[Any] = cast(List[Any], batches_any) if isinstance(batches_any, list) else []
 
-    lines: List[str] = [t("action.summary.complete", "✅ Visualization generation complete.")]
+    has_charts = isinstance(chart_count, int) and chart_count > 0
+    has_stats = isinstance(stats_count, int) and stats_count > 0
 
-    if isinstance(trace_id, str) and trace_id.strip():
-        lines.append(
-            t(
-                "action.summary.trace_id",
-                "Trace ID: {trace_id}",
-                {"trace_id": trace_id.strip()},
-            )
-        )
-
-    if isinstance(chart_count, int):
-        has_stats = isinstance(stats_count, int) and stats_count > 0
-        if has_stats:
-            if chart_count == 1:
-                lines.append(t("action.summary.plan_produced_one_chart", "Plan produced 1 chart."))
-            elif chart_count > 1:
-                lines.append(
-                    t(
-                        "action.summary.plan_produced_many_charts",
-                        "Plan produced {chart_count} charts.",
-                        {"chart_count": chart_count},
-                    )
-                )
+    if has_charts and has_stats:
+        lines: List[str] = [t("action.summary.complete_mixed", "Here's your chart and statistical comparison.")]
+    elif has_charts:
+        if chart_count == 1:
+            lines = [t("action.summary.complete_chart_one", "Here's your chart.")]
         else:
-            if chart_count == 1:
-                lines.append(t("action.summary.plan_produced_one_chart", "Plan produced 1 chart."))
-            else:
-                lines.append(
-                    t(
-                        "action.summary.plan_produced_many_charts",
-                        "Plan produced {chart_count} charts.",
-                        {"chart_count": chart_count},
-                    )
-                )
-
-    if isinstance(stats_count, int) and stats_count > 0:
+            lines = [t("action.summary.complete_chart_many", "Here are your {chart_count} charts.", {"chart_count": chart_count})]
+    elif has_stats:
         if stats_count == 1:
-            lines.append(t("action.summary.plan_produced_one_stat", "Plan produced 1 statistical test result."))
+            lines = [t("action.summary.complete_stat_one", "Here's your statistical comparison.")]
+        else:
+            lines = [t("action.summary.complete_stat_many", "Here are your {stats_count} statistical comparisons.", {"stats_count": stats_count})]
+    else:
+        lines = [t("action.summary.complete_fallback", "Done!")]
+
+    if isinstance(stats_errors, int) and stats_errors > 0:
+        if stats_errors == 1:
+            lines.append(t("action.summary.stats_errors_one", "One statistical test couldn't be completed."))
         else:
             lines.append(
                 t(
-                    "action.summary.plan_produced_many_stats",
-                    "Plan produced {stats_count} statistical test results.",
-                    {"stats_count": stats_count},
-                )
-            )
-        if isinstance(stats_skipped, int) and stats_skipped > 0:
-            lines.append(
-                t(
-                    "action.summary.stats_skipped",
-                    "Skipped {stats_skipped} statistical test result(s).",
-                    {"stats_skipped": stats_skipped},
-                )
-            )
-        if isinstance(stats_errors, int) and stats_errors > 0:
-            lines.append(
-                t(
-                    "action.summary.stats_errors",
-                    "{stats_errors} statistical test result(s) returned errors.",
+                    "action.summary.stats_errors_many",
+                    "{stats_errors} statistical tests couldn't be completed.",
                     {"stats_errors": stats_errors},
                 )
             )
-
-    if isinstance(planner_diagnostics, dict):
-        cache_hit = planner_diagnostics.get("last_call_cache_hit")
-        total_hits = planner_diagnostics.get("total_hits")
-        total_misses = planner_diagnostics.get("total_misses")
-        total_expired = planner_diagnostics.get("total_expired")
-        entries = planner_diagnostics.get("entries")
-        capacity = planner_diagnostics.get("capacity")
-        ttl_seconds = planner_diagnostics.get("ttl_seconds")
-        key_version = planner_diagnostics.get("key_version")
-
-        if cache_hit is True:
-            lines.append(
-                t(
-                    "action.summary.planner_cache_hit",
-                    "Planner cache: hit (reused a previously generated plan).",
-                )
-            )
-        elif cache_hit is False:
-            lines.append(
-                t(
-                    "action.summary.planner_cache_miss",
-                    "Planner cache: miss (generated a fresh plan).",
-                )
-            )
-
-        stats: List[str] = []
-        if isinstance(total_hits, int) and isinstance(total_misses, int):
-            stats.append(f"hits={total_hits}")
-            stats.append(f"misses={total_misses}")
-        if isinstance(total_expired, int):
-            stats.append(f"expired={total_expired}")
-        if isinstance(entries, int) and isinstance(capacity, int):
-            stats.append(f"entries={entries}/{capacity}")
-        if isinstance(ttl_seconds, (int, float)):
-            stats.append(f"ttl={int(ttl_seconds)}s")
-        if isinstance(key_version, str) and key_version:
-            stats.append(f"cache_key={key_version}")
-        if stats:
-            lines.append(" - " + "; ".join(stats))
-
-    if isinstance(actual, int):
-        if actual == 1:
-            lines.append(
-                t(
-                    "action.summary.queried_once",
-                    "I queried the analytics service once.",
-                )
-            )
+    elif isinstance(stats_skipped, int) and stats_skipped > 0:
+        if stats_skipped == 1:
+            lines.append(t("action.summary.stats_skipped_one", "One statistical test was skipped."))
         else:
             lines.append(
                 t(
-                    "action.summary.queried_many",
-                    "I queried the analytics service {actual} times.",
-                    {"actual": actual},
-                )
-            )
-
-        if isinstance(estimated, int) and estimated != actual:
-            lines.append(
-                t(
-                    "action.summary.planner_estimate",
-                    "Planner estimate was {estimated} request(s).",
-                    {"estimated": estimated},
-                )
-            )
-
-    if show_normalization and normalization is not None:
-        charts_in = normalization.get("charts_in")
-        charts_out = normalization.get("charts_out")
-        dropped_charts = normalization.get("dropped_empty_charts")
-        metrics_in = normalization.get("metrics_in")
-        metrics_out = normalization.get("metrics_out")
-        dropped_metrics = normalization.get("dropped_empty_metrics")
-        metric_code_norm = normalization.get("normalized_metric_codes")
-        chart_type_norm = normalization.get("normalized_chart_types")
-        deduped_groupby = normalization.get("deduped_groupby_entries")
-        normalized_groupby_fields = normalization.get("normalized_canonical_groupby_fields")
-        dropped_groupby_fields = normalization.get("dropped_invalid_groupby_fields")
-        chart_type_fallback = normalization.get("fallback_chart_type_count")
-        normalized_text = normalization.get("normalized_text_fields")
-
-        if isinstance(charts_in, int) and isinstance(charts_out, int):
-            lines.append(t("action.summary.plan_normalization", "Plan normalization:"))
-            lines.append(
-                " - "
-                + t(
-                    "action.summary.charts_transition",
-                    "Charts: {charts_in} -> {charts_out}",
-                    {"charts_in": charts_in, "charts_out": charts_out},
-                )
-            )
-
-            details: List[str] = []
-            if isinstance(dropped_charts, int) and dropped_charts > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_dropped_charts",
-                        "dropped {dropped_charts} empty chart(s)",
-                        {"dropped_charts": dropped_charts},
-                    )
-                )
-            if isinstance(metrics_in, int) and isinstance(metrics_out, int) and metrics_in != metrics_out:
-                details.append(
-                    t(
-                        "action.summary.detail_metrics_transition",
-                        "metrics {metrics_in} -> {metrics_out}",
-                        {"metrics_in": metrics_in, "metrics_out": metrics_out},
-                    )
-                )
-            if isinstance(dropped_metrics, int) and dropped_metrics > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_dropped_metrics",
-                        "dropped {dropped_metrics} empty metric(s)",
-                        {"dropped_metrics": dropped_metrics},
-                    )
-                )
-            if isinstance(metric_code_norm, int) and metric_code_norm > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_normalized_metric_codes",
-                        "normalized {metric_code_norm} metric code(s)",
-                        {"metric_code_norm": metric_code_norm},
-                    )
-                )
-            if isinstance(chart_type_norm, int) and chart_type_norm > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_normalized_chart_types",
-                        "normalized {chart_type_norm} chart type(s)",
-                        {"chart_type_norm": chart_type_norm},
-                    )
-                )
-            if isinstance(chart_type_fallback, int) and chart_type_fallback > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_applied_chart_fallback",
-                        "applied {chart_type_fallback} chart type fallback(s)",
-                        {"chart_type_fallback": chart_type_fallback},
-                    )
-                )
-            if isinstance(deduped_groupby, int) and deduped_groupby > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_removed_groupby_duplicates",
-                        "removed {deduped_groupby} duplicate group-by entries",
-                        {"deduped_groupby": deduped_groupby},
-                    )
-                )
-            if isinstance(normalized_groupby_fields, int) and normalized_groupby_fields > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_normalized_groupby_fields",
-                        "normalized {normalized_groupby_fields} canonical group-by field(s)",
-                        {"normalized_groupby_fields": normalized_groupby_fields},
-                    )
-                )
-            if isinstance(dropped_groupby_fields, int) and dropped_groupby_fields > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_dropped_groupby_fields",
-                        "dropped {dropped_groupby_fields} invalid group-by field(s)",
-                        {"dropped_groupby_fields": dropped_groupby_fields},
-                    )
-                )
-            if isinstance(normalized_text, int) and normalized_text > 0:
-                details.append(
-                    t(
-                        "action.summary.detail_cleaned_text_fields",
-                        "cleaned {normalized_text} text field(s)",
-                        {"normalized_text": normalized_text},
-                    )
-                )
-
-            if details:
-                lines.append(" - " + "; ".join(details))
-            else:
-                lines.append(
-                    " - "
-                    + t(
-                        "action.summary.no_structural_changes",
-                        "No structural changes were needed.",
-                    )
-                )
-
-    if batches:
-        lines.append(t("action.summary.what_i_queried", "What I queried:"))
-        max_batches = 4
-        for idx, batch_any in enumerate(batches[:max_batches], start=1):
-            if not isinstance(batch_any, dict):
-                continue
-            batch = cast(Dict[str, Any], batch_any)
-
-            query_count = batch.get("query_count")
-            groupby = batch.get("server_groupby")
-            periods = batch.get("batched_time_period_count")
-            filters_any = batch.get("filter_dimensions")
-            filters_list: List[Any] = cast(List[Any], filters_any) if isinstance(filters_any, list) else []
-            filter_names = [str(x).replace("GroupBy", "").strip() for x in filters_list]
-
-            parts: List[str] = [f"{idx})"]
-            if isinstance(query_count, int):
-                parts.append(
-                    t(
-                        "action.summary.request_count",
-                        "{query_count} request(s)",
-                        {"query_count": query_count},
-                    )
-                )
-            if isinstance(groupby, str) and groupby:
-                parts.append(
-                    t(
-                        "action.summary.grouped_by",
-                        "grouped by {groupby}",
-                        {"groupby": groupby},
-                    )
-                )
-            if isinstance(periods, int) and periods > 0:
-                parts.append(
-                    t(
-                        "action.summary.across_periods",
-                        "across {periods} time period(s)",
-                        {"periods": periods},
-                    )
-                )
-            if filter_names:
-                parts.append(
-                    t(
-                        "action.summary.split_by",
-                        "split by {filters}",
-                        {"filters": ", ".join(filter_names)},
-                    )
-                )
-
-            lines.append(" - " + " | ".join(parts))
-
-        remaining = len(batches) - max_batches
-        if remaining > 0:
-            lines.append(
-                " - "
-                + t(
-                    "action.summary.remaining_batches",
-                    "... and {remaining} more query batch(es)",
-                    {"remaining": remaining},
+                    "action.summary.stats_skipped_many",
+                    "{stats_skipped} statistical tests were skipped.",
+                    {"stats_skipped": stats_skipped},
                 )
             )
 

--- a/src/actions/helpers/visualization.py
+++ b/src/actions/helpers/visualization.py
@@ -486,6 +486,7 @@ def serialize_plan_for_frontend(plan: Any) -> Dict[str, Any]:
 def format_execution_summary(
     summary: Dict[str, Any] | Any,
     language: Optional[str] = None,
+    include_opening_line: bool = True,
 ) -> str:
     """A short, natural closing line for the chat -- the chart(s)/stat(s)
     themselves render in the UI, so this doesn't need to describe them in
@@ -493,7 +494,16 @@ def format_execution_summary(
     id, cache stats, query batching, plan normalization) used to be dumped
     here too; that's developer information, not something an end user
     needs, and CVaLab's own debug chat already surfaces it from the
-    structured payload -- see visualization_plan/visualization_response."""
+    structured payload -- see visualization_plan/visualization_response.
+
+    `include_opening_line` exists because the one-shot flow
+    (visualization_action.py) already sends its own specific confirmation
+    via `_build_confirmation_message` (e.g. "Here's your line chart of
+    DTN.") before calling this -- without it, callers would get two
+    redundant "here's your chart" sentences back to back. The guided flow
+    has no such confirmation elsewhere, so it keeps the default. May return
+    an empty string (e.g. opening line suppressed and nothing else to add);
+    callers should skip sending a message in that case."""
     def t(key: str, default: str, params: Optional[Dict[str, Any]] = None) -> str:
         return translate(key, language=language, params=params, default=default)
 
@@ -501,7 +511,7 @@ def format_execution_summary(
     if summary_dict is None and isinstance(summary, dict):
         summary_dict = _mapping_to_dict(summary)
     if summary_dict is None:
-        return t("action.summary.complete_fallback", "Done!")
+        return t("action.summary.complete_fallback", "Done!") if include_opening_line else ""
 
     chart_count = summary_dict.get("chart_count")
     stats_count = summary_dict.get("stats_count")
@@ -511,20 +521,22 @@ def format_execution_summary(
     has_charts = isinstance(chart_count, int) and chart_count > 0
     has_stats = isinstance(stats_count, int) and stats_count > 0
 
-    if has_charts and has_stats:
-        lines: List[str] = [t("action.summary.complete_mixed", "Here's your chart and statistical comparison.")]
-    elif has_charts:
-        if chart_count == 1:
-            lines = [t("action.summary.complete_chart_one", "Here's your chart.")]
+    lines: List[str] = []
+    if include_opening_line:
+        if has_charts and has_stats:
+            lines.append(t("action.summary.complete_mixed", "Here's your chart and statistical comparison."))
+        elif has_charts:
+            if chart_count == 1:
+                lines.append(t("action.summary.complete_chart_one", "Here's your chart."))
+            else:
+                lines.append(t("action.summary.complete_chart_many", "Here are your {chart_count} charts.", {"chart_count": chart_count}))
+        elif has_stats:
+            if stats_count == 1:
+                lines.append(t("action.summary.complete_stat_one", "Here's your statistical comparison."))
+            else:
+                lines.append(t("action.summary.complete_stat_many", "Here are your {stats_count} statistical comparisons.", {"stats_count": stats_count}))
         else:
-            lines = [t("action.summary.complete_chart_many", "Here are your {chart_count} charts.", {"chart_count": chart_count})]
-    elif has_stats:
-        if stats_count == 1:
-            lines = [t("action.summary.complete_stat_one", "Here's your statistical comparison.")]
-        else:
-            lines = [t("action.summary.complete_stat_many", "Here are your {stats_count} statistical comparisons.", {"stats_count": stats_count})]
-    else:
-        lines = [t("action.summary.complete_fallback", "Done!")]
+            lines.append(t("action.summary.complete_fallback", "Done!"))
 
     if isinstance(stats_errors, int) and stats_errors > 0:
         if stats_errors == 1:

--- a/src/locales/cs/common.json
+++ b/src/locales/cs/common.json
@@ -1,7 +1,7 @@
 {
   "action": {
     "common": {
-      "error_with_context": "❌ {message} (Kód chyby: {code}, Trace ID: {trace_id})"
+      "error_with_context": "{message}"
     },
     "visualization": {
       "clarify_default": "Potřebuji ještě trochu více detailů, než mohu vygenerovat vizualizaci.",
@@ -9,7 +9,7 @@
       "empty_plan_clarify": "Z tohoto požadavku se mi nepodařilo odvodit spustitelný analytický plán. Zadejte požadavek na graf s metrikou a typem grafu, nebo u statistiky uveďte dvě explicitní kohorty k porovnání.",
       "reject_default": "Tento požadavek je mimo tok vizualizace.",
       "non_visualization_intent": "Mohu pomoci s požadavky na vizualizaci. Zkuste požádat o vytvoření grafu nebo o aktualizaci aktuálního grafu.",
-      "success_complete": "✅ Generování vizualizace dokončeno.",
+      "success_complete": "Hotovo!",
       "internal_error_routing": "Chyba při směrování požadavku na vizualizaci: {error}",
       "internal_error_generating": "Chyba při generování vizualizace: {error}",
       "internal_error_guided": "Chyba při generování řízené vizualizace: {error}"
@@ -65,38 +65,16 @@
       "prompt_chart_type": "Nepodařilo se mi přiřadit tento typ grafu. Zadejte platný typ grafu nebo krok přeskočte."
     },
     "summary": {
-      "complete": "✅ Generování vizualizace dokončeno.",
-      "trace_id": "Trace ID: {trace_id}",
-      "plan_produced_one_chart": "Plán vytvořil 1 graf.",
-      "plan_produced_many_charts": "Plán vytvořil {chart_count} grafů.",
-      "plan_produced_one_stat": "Plán vytvořil 1 výsledek statistického testu.",
-      "plan_produced_many_stats": "Plán vytvořil {stats_count} výsledků statistických testů.",
-      "stats_skipped": "Přeskočeno {stats_skipped} výsledků statistických testů.",
-      "stats_errors": "{stats_errors} výsledků statistických testů vrátilo chybu.",
-      "planner_cache_hit": "Cache plánovače: hit (znovupoužit dříve vytvořený plán).",
-      "planner_cache_miss": "Cache plánovače: miss (vygenerován nový plán).",
-      "queried_once": "Analytickou službu jsem dotázal jednou.",
-      "queried_many": "Analytickou službu jsem dotázal {actual}krát.",
-      "planner_estimate": "Odhad plánovače byl {estimated} požadavek(y).",
-      "plan_normalization": "Normalizace plánu:",
-      "charts_transition": "Grafy: {charts_in} -> {charts_out}",
-      "detail_dropped_charts": "odebráno {dropped_charts} prázdných grafů",
-      "detail_metrics_transition": "metriky {metrics_in} -> {metrics_out}",
-      "detail_dropped_metrics": "odebráno {dropped_metrics} prázdných metrik",
-      "detail_normalized_metric_codes": "normalizováno {metric_code_norm} kódů metrik",
-      "detail_normalized_chart_types": "normalizováno {chart_type_norm} typů grafů",
-      "detail_applied_chart_fallback": "aplikováno {chart_type_fallback} fallback typů grafu",
-      "detail_removed_groupby_duplicates": "odebráno {deduped_groupby} duplicitních položek group-by",
-      "detail_normalized_groupby_fields": "normalizováno {normalized_groupby_fields} kanonických polí group-by",
-      "detail_dropped_groupby_fields": "odebráno {dropped_groupby_fields} neplatných polí group-by",
-      "detail_cleaned_text_fields": "vyčištěno {normalized_text} textových polí",
-      "no_structural_changes": "Nebyly potřeba žádné strukturální změny.",
-      "what_i_queried": "Co jsem dotazoval:",
-      "request_count": "{query_count} požadavek(y)",
-      "grouped_by": "seskupeno podle {groupby}",
-      "across_periods": "napříč {periods} časovým(i) obdobím(i)",
-      "split_by": "rozděleno podle {filters}",
-      "remaining_batches": "... a ještě {remaining} dalších dávkových dotazů"
+      "complete_chart_one": "Tady je váš graf.",
+      "complete_chart_many": "Tady máte {chart_count} grafů.",
+      "complete_stat_one": "Tady je vaše statistické srovnání.",
+      "complete_stat_many": "Tady máte {stats_count} statistických srovnání.",
+      "complete_mixed": "Tady je váš graf a statistické srovnání.",
+      "complete_fallback": "Hotovo!",
+      "stats_skipped_one": "Jeden statistický test byl přeskočen.",
+      "stats_skipped_many": "Bylo přeskočeno {stats_skipped} statistických testů.",
+      "stats_errors_one": "Jeden statistický test se nepodařilo dokončit.",
+      "stats_errors_many": "Nepodařilo se dokončit {stats_errors} statistických testů."
     }
   }
 }

--- a/src/locales/el/common.json
+++ b/src/locales/el/common.json
@@ -1,7 +1,7 @@
 {
   "action": {
     "common": {
-      "error_with_context": "❌ {message} (Κωδικός σφάλματος: {code}, Trace ID: {trace_id})"
+      "error_with_context": "{message}"
     },
     "visualization": {
       "clarify_default": "Χρειάζομαι λίγο περισσότερες λεπτομέρειες πριν δημιουργήσω την οπτικοποίηση.",
@@ -9,7 +9,7 @@
       "empty_plan_clarify": "Δεν μπόρεσα να συνθέσω εκτελέσιμο πλάνο ανάλυσης από αυτό το αίτημα. Ζητήστε γράφημα με μετρική και τύπο γραφήματος ή, για στατιστική σύγκριση, δώστε δύο ρητές ομάδες προς σύγκριση.",
       "reject_default": "Αυτό το αίτημα είναι εκτός της ροής οπτικοποίησης.",
       "non_visualization_intent": "Μπορώ να βοηθήσω με αιτήματα οπτικοποίησης. Ζητήστε να δημιουργηθεί ένα γράφημα ή να ενημερωθεί το τρέχον γράφημα.",
-      "success_complete": "✅ Η δημιουργία οπτικοποίησης ολοκληρώθηκε.",
+      "success_complete": "Ολοκληρώθηκε!",
       "internal_error_routing": "Σφάλμα δρομολόγησης αιτήματος οπτικοποίησης: {error}",
       "internal_error_generating": "Σφάλμα δημιουργίας οπτικοποίησης: {error}",
       "internal_error_guided": "Σφάλμα δημιουργίας καθοδηγούμενης οπτικοποίησης: {error}"
@@ -65,38 +65,16 @@
       "prompt_chart_type": "Δεν μπόρεσα να αντιστοιχίσω αυτόν τον τύπο γραφήματος. Εισάγετε έγκυρο τύπο γραφήματος ή παραλείψτε."
     },
     "summary": {
-      "complete": "✅ Η δημιουργία οπτικοποίησης ολοκληρώθηκε.",
-      "trace_id": "Trace ID: {trace_id}",
-      "plan_produced_one_chart": "Το πλάνο παρήγαγε 1 γράφημα.",
-      "plan_produced_many_charts": "Το πλάνο παρήγαγε {chart_count} γραφήματα.",
-      "plan_produced_one_stat": "Το πλάνο παρήγαγε 1 αποτέλεσμα στατιστικού τεστ.",
-      "plan_produced_many_stats": "Το πλάνο παρήγαγε {stats_count} αποτελέσματα στατιστικών τεστ.",
-      "stats_skipped": "Παραλείφθηκαν {stats_skipped} αποτέλεσμα(τα) στατιστικών τεστ.",
-      "stats_errors": "{stats_errors} αποτέλεσμα(τα) στατιστικών τεστ επέστρεψαν σφάλμα.",
-      "planner_cache_hit": "Cache planner: hit (επαναχρησιμοποίηση προηγούμενου πλάνου).",
-      "planner_cache_miss": "Cache planner: miss (δημιουργήθηκε νέο πλάνο).",
-      "queried_once": "Έκανα ένα ερώτημα στην υπηρεσία analytics.",
-      "queried_many": "Έκανα {actual} ερωτήματα στην υπηρεσία analytics.",
-      "planner_estimate": "Η εκτίμηση του planner ήταν {estimated} αίτημα(τα).",
-      "plan_normalization": "Κανονικοποίηση πλάνου:",
-      "charts_transition": "Γραφήματα: {charts_in} -> {charts_out}",
-      "detail_dropped_charts": "αφαιρέθηκαν {dropped_charts} κενό(ά) γράφημα(τα)",
-      "detail_metrics_transition": "μετρικές {metrics_in} -> {metrics_out}",
-      "detail_dropped_metrics": "αφαιρέθηκαν {dropped_metrics} κενή(ές) μετρική(ές)",
-      "detail_normalized_metric_codes": "κανονικοποιήθηκαν {metric_code_norm} κωδικοί μετρικών",
-      "detail_normalized_chart_types": "κανονικοποιήθηκαν {chart_type_norm} τύποι γραφημάτων",
-      "detail_applied_chart_fallback": "εφαρμόστηκαν {chart_type_fallback} fallback τύπου γραφήματος",
-      "detail_removed_groupby_duplicates": "αφαιρέθηκαν {deduped_groupby} διπλές εγγραφές group-by",
-      "detail_normalized_groupby_fields": "κανονικοποιήθηκαν {normalized_groupby_fields} πεδία canonical group-by",
-      "detail_dropped_groupby_fields": "αφαιρέθηκαν {dropped_groupby_fields} μη έγκυρα πεδία group-by",
-      "detail_cleaned_text_fields": "καθαρίστηκαν {normalized_text} πεδία κειμένου",
-      "no_structural_changes": "Δεν χρειάστηκαν δομικές αλλαγές.",
-      "what_i_queried": "Τι ερωτήματα έστειλα:",
-      "request_count": "{query_count} αίτημα(τα)",
-      "grouped_by": "ομαδοποίηση κατά {groupby}",
-      "across_periods": "σε {periods} χρονική(ές) περίοδο(ους)",
-      "split_by": "διαχωρισμός κατά {filters}",
-      "remaining_batches": "... και {remaining} ακόμα batch(es) ερωτημάτων"
+      "complete_chart_one": "Ορίστε το γράφημά σας.",
+      "complete_chart_many": "Ορίστε τα {chart_count} γραφήματά σας.",
+      "complete_stat_one": "Ορίστε τη στατιστική σας σύγκριση.",
+      "complete_stat_many": "Ορίστε τις {stats_count} στατιστικές συγκρίσεις σας.",
+      "complete_mixed": "Ορίστε το γράφημα και τη στατιστική σύγκριση.",
+      "complete_fallback": "Ολοκληρώθηκε!",
+      "stats_skipped_one": "Μία στατιστική δοκιμή παραλείφθηκε.",
+      "stats_skipped_many": "{stats_skipped} στατιστικές δοκιμές παραλείφθηκαν.",
+      "stats_errors_one": "Μία στατιστική δοκιμή δεν ολοκληρώθηκε.",
+      "stats_errors_many": "{stats_errors} στατιστικές δοκιμές δεν ολοκληρώθηκαν."
     }
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,7 +1,7 @@
 {
   "action": {
     "common": {
-      "error_with_context": "❌ {message}"
+      "error_with_context": "{message}"
     },
     "visualization": {
       "clarify_default": "I need a bit more detail before I can generate a visualization.",
@@ -9,7 +9,7 @@
       "empty_plan_clarify": "I could not derive an executable analysis plan from that request. Please ask for a chart with metric and chart type, or for statistics provide two explicit cohorts to compare.",
       "reject_default": "This request is outside the visualization flow.",
       "non_visualization_intent": "I can help with visualization requests. Try asking to generate a chart, or ask to update the current chart.",
-      "success_complete": "✅ Visualization generation complete.",
+      "success_complete": "Done!",
       "internal_error_routing": "Error routing visualization request: {error}",
       "internal_error_generating": "Error generating visualization: {error}",
       "internal_error_guided": "Error generating guided visualization: {error}",
@@ -68,38 +68,16 @@
       "prompt_chart_type": "I couldn't match that chart type. Please enter a valid chart type or skip."
     },
     "summary": {
-      "complete": "✅ Visualization generation complete.",
-      "trace_id": "Trace ID: {trace_id}",
-      "plan_produced_one_chart": "Plan produced 1 chart.",
-      "plan_produced_many_charts": "Plan produced {chart_count} charts.",
-      "plan_produced_one_stat": "Plan produced 1 statistical test result.",
-      "plan_produced_many_stats": "Plan produced {stats_count} statistical test results.",
-      "stats_skipped": "Skipped {stats_skipped} statistical test result(s).",
-      "stats_errors": "{stats_errors} statistical test result(s) returned errors.",
-      "planner_cache_hit": "Planner cache: hit (reused a previously generated plan).",
-      "planner_cache_miss": "Planner cache: miss (generated a fresh plan).",
-      "queried_once": "I queried the analytics service once.",
-      "queried_many": "I queried the analytics service {actual} times.",
-      "planner_estimate": "Planner estimate was {estimated} request(s).",
-      "plan_normalization": "Plan normalization:",
-      "charts_transition": "Charts: {charts_in} -> {charts_out}",
-      "detail_dropped_charts": "dropped {dropped_charts} empty chart(s)",
-      "detail_metrics_transition": "metrics {metrics_in} -> {metrics_out}",
-      "detail_dropped_metrics": "dropped {dropped_metrics} empty metric(s)",
-      "detail_normalized_metric_codes": "normalized {metric_code_norm} metric code(s)",
-      "detail_normalized_chart_types": "normalized {chart_type_norm} chart type(s)",
-      "detail_applied_chart_fallback": "applied {chart_type_fallback} chart type fallback(s)",
-      "detail_removed_groupby_duplicates": "removed {deduped_groupby} duplicate group-by entries",
-      "detail_normalized_groupby_fields": "normalized {normalized_groupby_fields} canonical group-by field(s)",
-      "detail_dropped_groupby_fields": "dropped {dropped_groupby_fields} invalid group-by field(s)",
-      "detail_cleaned_text_fields": "cleaned {normalized_text} text field(s)",
-      "no_structural_changes": "No structural changes were needed.",
-      "what_i_queried": "What I queried:",
-      "request_count": "{query_count} request(s)",
-      "grouped_by": "grouped by {groupby}",
-      "across_periods": "across {periods} time period(s)",
-      "split_by": "split by {filters}",
-      "remaining_batches": "... and {remaining} more query batch(es)"
+      "complete_chart_one": "Here's your chart.",
+      "complete_chart_many": "Here are your {chart_count} charts.",
+      "complete_stat_one": "Here's your statistical comparison.",
+      "complete_stat_many": "Here are your {stats_count} statistical comparisons.",
+      "complete_mixed": "Here's your chart and statistical comparison.",
+      "complete_fallback": "Done!",
+      "stats_skipped_one": "One statistical test was skipped.",
+      "stats_skipped_many": "{stats_skipped} statistical tests were skipped.",
+      "stats_errors_one": "One statistical test couldn't be completed.",
+      "stats_errors_many": "{stats_errors} statistical tests couldn't be completed."
     }
   }
 }

--- a/tests/test_visualization_summary_stats.py
+++ b/tests/test_visualization_summary_stats.py
@@ -46,42 +46,74 @@ def _load_format_execution_summary():
 
 
 class VisualizationSummaryStatsTests(unittest.TestCase):
-    def test_stats_only_summary_does_not_report_zero_charts(self) -> None:
+    def test_stats_only_summary_does_not_mention_charts(self) -> None:
+        formatter = _load_format_execution_summary()
+        summary = {
+            "chart_count": 0,
+            "stats_count": 1,
+        }
+
+        msg = formatter(summary, language="en")
+
+        self.assertEqual(msg, "Here's your statistical comparison.")
+
+    def test_mixed_summary_reports_a_single_natural_line_no_technical_detail(self) -> None:
         formatter = _load_format_execution_summary()
         summary = {
             "trace_id": "abc123",
-            "chart_count": 0,
-            "stats_count": 1,
-            "stats_skipped": 0,
-            "stats_errors": 0,
-            "estimated_queries": 1,
-            "actual_queries": 1,
-            "batches": [],
+            "chart_count": 1,
+            "stats_count": 3,
+            "estimated_queries": 4,
+            "actual_queries": 4,
         }
 
-        msg = formatter(summary, show_normalization=False, planner_diagnostics=None, language="en")
+        msg = formatter(summary, language="en")
 
-        self.assertIn("Plan produced 1 statistical test result.", msg)
-        self.assertNotIn("Plan produced 0 charts.", msg)
+        self.assertEqual(msg, "Here's your chart and statistical comparison.")
+        # None of the developer diagnostics this used to dump into the chat
+        # should ever appear -- see CVaLab for that detail instead.
+        self.assertNotIn("Trace ID", msg)
+        self.assertNotIn("queried", msg)
+        self.assertNotIn("cache", msg.lower())
 
-    def test_stats_summary_includes_skip_and_error_counts(self) -> None:
+    def test_stats_errors_take_priority_over_skipped_count(self) -> None:
         formatter = _load_format_execution_summary()
         summary = {
             "chart_count": 1,
             "stats_count": 3,
             "stats_skipped": 1,
             "stats_errors": 1,
-            "estimated_queries": 4,
-            "actual_queries": 4,
-            "batches": [],
         }
 
-        msg = formatter(summary, show_normalization=False, planner_diagnostics=None, language="en")
+        msg = formatter(summary, language="en")
 
-        self.assertIn("Plan produced 1 chart.", msg)
-        self.assertIn("Plan produced 3 statistical test results.", msg)
-        self.assertIn("Skipped 1 statistical test result(s).", msg)
-        self.assertIn("1 statistical test result(s) returned errors.", msg)
+        self.assertIn("One statistical test couldn't be completed.", msg)
+        self.assertNotIn("skipped", msg.lower())
+
+    def test_many_charts_and_skipped_stats_use_plural_phrasing(self) -> None:
+        formatter = _load_format_execution_summary()
+        summary = {
+            "chart_count": 2,
+            "stats_count": 2,
+            "stats_skipped": 2,
+        }
+
+        msg = formatter(summary, language="en")
+
+        self.assertIn("Here's your chart and statistical comparison.", msg)
+        self.assertIn("2 statistical tests were skipped.", msg)
+
+    def test_no_emoji_anywhere_in_output(self) -> None:
+        formatter = _load_format_execution_summary()
+        for summary in (
+            {"chart_count": 1, "stats_count": 0},
+            {"chart_count": 0, "stats_count": 1},
+            {"chart_count": 2, "stats_count": 2, "stats_errors": 1},
+            {},
+        ):
+            msg = formatter(summary, language="en")
+            for ch in msg:
+                self.assertLess(ord(ch), 0x1F300, f"unexpected emoji-range character in: {msg!r}")
 
 
 if __name__ == "__main__":

--- a/tests/test_visualization_summary_stats.py
+++ b/tests/test_visualization_summary_stats.py
@@ -103,6 +103,31 @@ class VisualizationSummaryStatsTests(unittest.TestCase):
         self.assertIn("Here's your chart and statistical comparison.", msg)
         self.assertIn("2 statistical tests were skipped.", msg)
 
+    def test_opening_line_can_be_suppressed_to_avoid_duplicate_confirmation(self) -> None:
+        # visualization_action.py's one-shot flow already sends its own
+        # specific confirmation (_build_confirmation_message) before this is
+        # called -- this must return empty (not "Here's your chart.") when
+        # there's nothing else to add, so callers don't send a second,
+        # redundant chat bubble.
+        formatter = _load_format_execution_summary()
+
+        msg = formatter({"chart_count": 1, "stats_count": 0}, language="en", include_opening_line=False)
+        self.assertEqual(msg, "")
+
+        msg = formatter({}, language="en", include_opening_line=False)
+        self.assertEqual(msg, "")
+
+    def test_opening_line_suppressed_still_reports_a_genuine_caveat(self) -> None:
+        formatter = _load_format_execution_summary()
+
+        msg = formatter(
+            {"chart_count": 1, "stats_count": 1, "stats_errors": 1},
+            language="en",
+            include_opening_line=False,
+        )
+
+        self.assertEqual(msg, "One statistical test couldn't be completed.")
+
     def test_no_emoji_anywhere_in_output(self) -> None:
         formatter = _load_format_execution_summary()
         for summary in (


### PR DESCRIPTION
## Summary
- format_execution_summary rewritten from a ~340-line technical dump (trace
  ID, planner cache stats, query batching, plan-normalization detail) down to
  short natural confirmation lines — that diagnostic detail now belongs in
  CVaLab, not the end-user chat
- Removed emoji repo-wide (checkmarks/crosses in error and success messages)
- Fixed a genuine en/el/cs inconsistency in action.common.error_with_context
  found while cleaning up translations (el/cs were appending an error-code/
  trace-ID suffix that en never had)
- Fixed a duplicate-confirmation bug the above cleanup surfaced: the one-shot
  visualization flow was sending both _build_confirmation_message's own
  "here's your chart" and format_execution_summary's — added an
  include_opening_line flag so the second call only adds genuine caveats
  (skipped/failed stats), never a redundant repeat