### PR TITLE
Add a GLUCOSE few-shot example to stop a hallucinated filter type

### DIFF
--- a/src/planners/langchain/fewshot_examples/glucose_line_basic.json
+++ b/src/planners/langchain/fewshot_examples/glucose_line_basic.json
@@ -1,0 +1,54 @@
+{
+  "category": "basic",
+  "user_utterance": "Show me a line graph of initial glucose",
+  "entities_detected": {
+    "metric": [
+      "GLUCOSE"
+    ],
+    "chart_type": [
+      "LINE"
+    ]
+  },
+  "assistant": {
+    "charts": [
+      {
+        "chart_type": "LINE",
+        "semantics": {
+          "intent": "DISTRIBUTION",
+          "measure": {
+            "type": "DISTRIBUTION",
+            "percentile": null
+          },
+          "splits": null,
+          "time": null,
+          "x_axis": {
+            "role": "METRIC_VALUE",
+            "metric": "GLUCOSE",
+            "label": null,
+            "unit": null,
+            "aggregation": null,
+            "grain": null
+          },
+          "y_axis": {
+            "role": "COUNT",
+            "metric": null,
+            "label": null,
+            "unit": null,
+            "aggregation": null,
+            "grain": null
+          }
+        },
+        "filters": null,
+        "metrics": [
+          {
+            "metric": "GLUCOSE",
+            "data_origin": null,
+            "origin_scope": null
+          }
+        ],
+        "numeric_resolution": null
+      }
+    ],
+    "statistical_tests": null
+  }
+}


### PR DESCRIPTION
## Summary
GLUCOSE had zero few-shot examples anywhere in the planner prompt, so
the LLM had nothing demonstrating the correct pattern for it. For
"initial glucose" -- GLUCOSE's own SSOT synonym, so a very ordinary
phrasing -- the planner would sometimes invent a "GlucoseTypeFilter"
that doesn't exist anywhere in the schema (misreading "initial" as a
filter qualifier to encode, rather than just part of the metric's
name), failing Pydantic validation with 42 errors. The self-critique
retry loop sometimes caught and dropped it, sometimes exhausted its
retry budget and shipped the broken plan as-is, which then failed at
execution -- non-deterministic, so it read as flaky rather than a hard
bug at first.

New example (glucose_line_basic.json) demonstrates the correct plan
for exactly this phrasing: metric: GLUCOSE, filters: null. Every
example file is loaded unconditionally into every planning call (see
examples.py) and validated against the live schema at Action startup,
so this is the same fix-by-demonstration approach the codebase already
uses for every other metric/chart-type gap like this.