### PR TITLE
Stop the orchestrator misreading "or" in a resolved metric's own name

### DIFF
--- a/src/planners/langchain/prompts/decision_system.txt
+++ b/src/planners/langchain/prompts/decision_system.txt
@@ -43,5 +43,12 @@ Rules:
 - If out of scope, return decision="reject" with a short message.
 - Never ask the user to clarify or provide time_scope, time_range, grouping_dimension, sex, or stroke_type — these are optional and should be accepted if present, not rejected.
 - Prefer resolving metrics from VALID_METRIC_CANDIDATES_JSON before asking.
+- If ENTITIES_JSON already contains a resolved metric, never second-guess or
+  re-split that metric based on connector words ("or"/"and") appearing inside
+  USER_QUESTION's own phrasing of it -- a metric's natural-language name can
+  itself contain "or"/"and" (e.g. "stroke unit or intensive care" is one
+  metric, not a request to choose between two). Only treat a metric as
+  genuinely ambiguous when ENTITIES_JSON does NOT already contain a resolved
+  metric for it.
 - When a date entity contains only a year (e.g. "2026"), expand it to a full-year range: two DateFilters — operator GE with value "{{year}}-01-01" AND operator LE with value "{{year}}-12-31".
 - Do not include markdown or prose outside JSON.


### PR DESCRIPTION
## Summary
AA_STROKE_UNIT's synonym is "stroke unit or intensive care" -- a
single metric whose natural-language name happens to contain "or".
Even though ENTITIES_JSON already carried the correctly-resolved
metric (confirmed at the NLU layer, unaffected by this), the decision
stage's own semantic reading of USER_QUESTION's raw text kept
outweighing that resolution: it read "or" as a request to choose
between two metrics and hallucinated a nonexistent AA_INTENSIVE_CARE
clarification option -- 100% reproducible, not the sampling-based
flakiness seen in the earlier GLUCOSE fix.

decision_system.txt already stated "ENTITIES_JSON is the authoritative,
already-resolved set," but nothing told the model not to override that
resolution based on words inside the metric's own phrasing. Added an
explicit rule: don't second-guess or re-split an already-resolved
metric based on "or"/"and" appearing in USER_QUESTION's phrasing of it.

No few-shot mechanism exists for this decision stage (unlike plan
generation's fewshot_examples/*.json) -- this had to be a prompt-rule
fix, not a demonstrating-example fix.