### PR TITLE
Add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Action environment template.
+#
+# Loaded automatically via python-dotenv -- copy to .env in the repo
+# root. Real process env vars win over .env for the same key, so this
+# is safe alongside docker-compose environment: blocks too. Never
+# commit the real .env.
+
+# --- LLM (plan generation, orchestrator decisions) -----------------------
+
+LLM_PROVIDER=openai
+LLM_MODEL=gpt-4o
+# Real secret -- pull from wherever your team keeps it, never hardcode here.
+OPENAI_API_KEY=
+# LLM_API_KEY=
+# LLM_BASE_URL=
+# LLM_KWARGS_JSON=
+
+# --- Talking to Webapp (GraphQL/analytics data access) -------------------
+
+# Despite the name, this points at Webapp, not Rasa -- Webapp holds the
+# real per-user Keycloak token and proxies GraphQL requests on Action's
+# behalf.
+RASA_PROXY_URL=http://host.docker.internal:3000
+# Shared secret Webapp's rasa-proxy route checks -- must match Webapp's
+# own ACTION_SERVER_TOKEN.
+ACTION_SERVER_TOKEN=
+
+# --- Long-running visualization task callbacks ----------------------------
+
+# Shared secret the callback receiver checks -- same value as Webapp's/
+# CVaLab's LONG_TASK_CALLBACK_TOKEN.
+LONG_TASK_CALLBACK_TOKEN=
+# Fallback only -- CVaLab/Webapp both supply their own callback_url.
+# CALLBACK_BASE_URL=
+# Origins/paths the callback receiver accepts a callback_url from --
+# include wherever your Webapp/CVaLab devcontainers are reachable.
+LONG_TASK_CALLBACK_ALLOWED_ORIGINS=http://host.docker.internal:3000,http://host.docker.internal:4010
+# LONG_TASK_CALLBACK_ALLOWED_PATHS=
+
+# --- Tuning (all have sane defaults, rarely need changing) ---------------
+
+# ACTIONS_LLM_PLANNER_REQUEST_TIMEOUT_SECONDS=
+# ACTIONS_LLM_PLAN_GENERATION_TIMEOUT_SECONDS=
+# ACTIONS_LLM_REQUEST_ORCHESTRATOR_TIMEOUT_SECONDS=
+# ACTIONS_LLM_REQUEST_ORCHESTRATOR_TEMPERATURE=
+# ACTIONS_EXECUTE_PLAN_TIMEOUT_SECONDS=
+# ACTIONS_EXECUTOR_MAX_CONCURRENCY=
+# EXECUTOR_DEFAULT_MAX_CONCURRENCY=
+# EXECUTOR_SYNC_MAX_CONCURRENCY=
+# EXECUTOR_DEFAULT_ORIGIN_SCOPE=
+# EXECUTOR_GRAPHQL_TIMEOUT_SECONDS=
+# EXECUTOR_ORIGIN_SCOPE_TIMEOUT_SECONDS=
+# EXECUTOR_ORIGIN_SCOPE_MAX_PROVIDER_IDS=
+# EXECUTOR_PROVIDER_CACHE_TTL_SECONDS=
+# ANALYTICS_CENTER_LOG_QUERY=false
+# ANALYTICS_CENTER_LOG_UPSTREAM_PREVIEW=false
+
+# Dev convenience: .env values override already-set process env vars
+# instead of losing to them. Leave false unless troubleshooting.
+# ACTION_DOTENV_OVERRIDE=false

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 !/envgen.sh
 !/envgen.config
 !/requirements.txt
+!/.env.example
 
 # Add source
 !/src/**


### PR DESCRIPTION
## Summary
Documents every var Action's own code reads (grepped from source),
including the cross-repo ones that have to match another service's env
exactly (ACTION_SERVER_TOKEN, LONG_TASK_CALLBACK_TOKEN) and the
misleadingly-named RASA_PROXY_URL, which actually points at Webapp.

Added !/.env.example to .gitignore -- this repo's allowlist-style
gitignore was silently excluding the new file without its own entry.