### PR TITLE
Send a real /list_hospitals intent payload from pagination buttons

### DIFF
--- a/src/actions/actions/hospitals_action.py
+++ b/src/actions/actions/hospitals_action.py
@@ -92,7 +92,7 @@ def _build_pagination_buttons(*, offset: int, limit: int, total_count: int, lang
         buttons.append(
             {
                 "title": translate("action.hospitals.previous_page_button", language=language),
-                "payload": f"list hospitals {previous_offset}",
+                "payload": f'/list_hospitals{{"offset": {previous_offset}}}',
             }
         )
 
@@ -101,7 +101,7 @@ def _build_pagination_buttons(*, offset: int, limit: int, total_count: int, lang
         buttons.append(
             {
                 "title": translate("action.hospitals.next_page_button", language=language),
-                "payload": f"list hospitals {next_offset}",
+                "payload": f'/list_hospitals{{"offset": {next_offset}}}',
             }
         )
 

--- a/tests/test_hospitals_action.py
+++ b/tests/test_hospitals_action.py
@@ -40,7 +40,7 @@ def test_build_pagination_buttons_first_page_has_only_next() -> None:
 
     assert len(buttons) == 1
     assert buttons[0]["title"] == "Next"
-    assert buttons[0]["payload"] == "list hospitals 50"
+    assert buttons[0]["payload"] == '/list_hospitals{"offset": 50}'
 
 
 def test_build_pagination_buttons_middle_page_has_previous_and_next() -> None:
@@ -48,9 +48,9 @@ def test_build_pagination_buttons_middle_page_has_previous_and_next() -> None:
 
     assert len(buttons) == 2
     assert buttons[0]["title"] == "Previous"
-    assert buttons[0]["payload"] == "list hospitals 0"
+    assert buttons[0]["payload"] == '/list_hospitals{"offset": 0}'
     assert buttons[1]["title"] == "Next"
-    assert buttons[1]["payload"] == "list hospitals 100"
+    assert buttons[1]["payload"] == '/list_hospitals{"offset": 100}'
 
 
 def test_build_pagination_buttons_last_page_has_only_previous() -> None:
@@ -58,4 +58,4 @@ def test_build_pagination_buttons_last_page_has_only_previous() -> None:
 
     assert len(buttons) == 1
     assert buttons[0]["title"] == "Previous"
-    assert buttons[0]["payload"] == "list hospitals 50"
+    assert buttons[0]["payload"] == '/list_hospitals{"offset": 50}'


### PR DESCRIPTION
The pagination buttons sent plain text ("list hospitals 50"), relying on NLU to reclassify it as list_hospitals and correctly extract that bare number as offset rather than limit — fragile enough that extract_hospital_filters already carries an explicit workaround comment for exactly this misclassification. list_hospitals is a plain rule-routed action (list_hospitals → action_list_hospitals, no LLM involved), so there's no reason to go through NLU at all. Buttons now send /list_hospitals{"offset": N} directly.

Verified live, end-to-end: clicking the generated button produced intent confidence 1.0 with a correctly extracted offset entity (via Rasa's RegexMessageHandler), landing on the right page (51–100). Updated the 3 existing pagination tests to match; full test suite is clean (199 passed, 3 pre-existing unrelated failures in test_query_compiler_semantics.py).